### PR TITLE
Remove unnecessary include EGL/eglmesaext.h

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -2,7 +2,6 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <EGL/eglmesaext.h>
 #include <sys/socket.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This header is not apparently necessary, and it is not present in non-mesa SDKs.  