### PR TITLE
Add support for building using Meson

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
         run: |
           export PKG_CONFIG_PATH="${HOME}/libwpe-prefix/lib/pkgconfig/"
           mkdir -p _work/cmake/build && cd $_
-          cmake -DCMAKE_INSTALL_PREFIX=/usr \
-            -DBUILD_DOCS=OFF -DEXPORTABLE_EGL=ON ../../..
+          cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DOCS=OFF ../../..
       - name: CMake - Build
         run: |
           make -C _work/cmake/build -j$(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+---
+
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Debian Packages
+        run: |
+          sudo apt update
+          sudo apt install -y cmake flex libjson-glib-dev libxkbcommon-dev \
+            libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev llvm-dev \
+            libclang-dev libglib2.0-dev libepoxy-dev ninja-build
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Python Package Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install Python Packages
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson==0.49
+      - name: Fetch libwpe
+        run: |
+          if [[ -d ~/libwpe/.git ]] ; then
+            echo 'Updating libwpe clone...'
+            cd ~/libwpe/
+            git reset --hard
+            git clean -qxdff
+            git checkout -f master
+            git pull -q
+          else
+            echo 'Cloning libwpe afresh...'
+            rm -rf ~/libwpe/
+            git clone -q https://github.com/WebPlatformForEmbedded/libwpe ~/libwpe/
+          fi
+      - name: Build and Install libwpe
+        run: |
+          mkdir ~/libwpe-build/ && cd "$_"
+          cmake ~/libwpe/ -DBUILD_DOCS=OFF \
+            -DCMAKE_INSTALL_PREFIX=${HOME}/libwpe-prefix \
+            -DCMAKE_INSTALL_LIBDIR=${HOME}/libwpe-prefix/lib
+          TERM=dumb cmake --build . --parallel $(nproc) --target install
+      - name: Meson - Configure
+        run: |
+          export PKG_CONFIG_PATH="${HOME}/libwpe-prefix/lib/pkgconfig/"
+          mkdir -p _work/meson
+          meson _work/meson/build --prefix /usr -Dbuild_docs=true
+      - name: Meson - Build
+        run: |
+          ninja -C _work/meson/build
+      - name: Meson - Install
+        run: |
+          DESTDIR="$(pwd)/_work/meson/prefix" ninja -C _work/meson/build install
+          nm -D -P _work/meson/build/libWPEBackend-fdo-1.0.so \
+            | awk '$2 == "T" || $2 == "U" {print $2 " " $1}' \
+            | sort -u > _work/meson/symbols
+          (cd _work/meson/prefix && find usr/lib -type f | sort) \
+            > _work/meson/files
+      - name: Meson - Archive Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-meson
+          path: _work/meson/prefix
+      - name: CMake - Configure
+        run: |
+          export PKG_CONFIG_PATH="${HOME}/libwpe-prefix/lib/pkgconfig/"
+          mkdir -p _work/cmake/build && cd $_
+          cmake -DCMAKE_INSTALL_PREFIX=/usr \
+            -DBUILD_DOCS=OFF -DEXPORTABLE_EGL=ON ../../..
+      - name: CMake - Build
+        run: |
+          make -C _work/cmake/build -j$(nproc)
+      - name: CMake - Install
+        run: |
+          DESTDIR="$(pwd)/_work/cmake/prefix" make -C _work/cmake/build install
+          nm -D -P _work/cmake/build/libWPEBackend-fdo-1.0.so \
+            | awk '$2 == "T" || $2 == "U" {print $2 " " $1}' \
+            | sort -u > _work/cmake/symbols
+          (cd _work/cmake/prefix && find usr/lib -type f | sort) \
+            > _work/cmake/files
+      - name: CMake - Archive Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-cmake
+          path: _work/cmake/prefix
+      - name: Check Installations
+        run: |
+          diff -u _work/{cmake,meson}/files
+          diff -u _work/{cmake,meson}/symbols
+          diff -Naur _work/{cmake,meson}/prefix/usr/include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ find_package(WPE 1.5.90 REQUIRED)
 
 add_definitions(-DWPE_FDO_COMPILATION -DG_LOG_DOMAIN=\"WPE-FDO\")
 
-configure_file(include/wpe-fdo/version.h.cmake "${CMAKE_BINARY_DIR}/wpe-fdo/version.h" @ONLY)
+configure_file(include/wpe-fdo/version.h.cmake "${CMAKE_BINARY_DIR}/version.h" @ONLY)
 
 set(WPEBACKEND_FDO_INCLUDE_DIRECTORIES
     "include"
@@ -68,7 +68,7 @@ set(WPEBACKEND_FDO_LIBRARIES
 )
 
 set(WPEBACKEND_FDO_PUBLIC_HEADERS
-    ${CMAKE_BINARY_DIR}/wpe-fdo/version.h
+    ${CMAKE_BINARY_DIR}/version.h
     include/wpe-fdo/exported-image-egl.h
     include/wpe-fdo/exported-buffer-shm.h
     include/wpe-fdo/initialize-egl.h
@@ -86,8 +86,8 @@ set(WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS
 )
 
 set(WPEBACKEND_FDO_GENERATED_SOURCES
-    ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
-    ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-protocol.c
+    ${CMAKE_BINARY_DIR}/wpe-bridge-protocol.c
+    ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-protocol.c
 )
 
 set(WPEBACKEND_FDO_SOURCES
@@ -116,27 +116,25 @@ set(WPEBACKEND_FDO_SOURCES
     src/linux-dmabuf/linux-dmabuf-protocol.c
 )
 
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bridge)
 add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
-           ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-client-protocol.h
-           ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-server-protocol.h
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-bridge-protocol.c
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-bridge-client-protocol.h
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-bridge-server-protocol.h
     DEPENDS ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml
-    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
-    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-client-protocol.h
-    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-server-protocol.h
+    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/wpe-bridge-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/wpe-bridge-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/wpe-bridge-server-protocol.h
     VERBATIM
 )
 
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf)
 add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-protocol.c
-    OUTPUT ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-client-protocol.h
-    OUTPUT ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-server-protocol.h
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-protocol.c
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-client-protocol.h
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-server-protocol.h
     DEPENDS ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml
-    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-protocol.c
-    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-client-protocol.h
-    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-server-protocol.h
+    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-server-protocol.h
     VERBATIM
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(WPEBACKEND_FDO_PUBLIC_HEADERS
     include/wpe-fdo/exported-buffer-shm.h
     include/wpe-fdo/initialize-egl.h
     include/wpe-fdo/view-backend-exportable.h
+    include/wpe-fdo/view-backend-exportable-egl.h
     include/wpe-fdo/fdo-egl.h
     include/wpe-fdo/fdo.h
 )
@@ -108,6 +109,7 @@ set(WPEBACKEND_FDO_SOURCES
     src/renderer-host.cpp
     src/version.c
     src/view-backend-exportable-fdo.cpp
+    src/view-backend-exportable-fdo-egl.cpp
     src/view-backend-exportable-private.cpp
     src/ws.cpp
     src/ws-client.cpp
@@ -142,13 +144,6 @@ add_custom_command(
     COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-server-protocol.h
     VERBATIM
 )
-
-option(EXPORTABLE_EGL "Enable the exportable EGL interface" ON)
-
-if (EXPORTABLE_EGL)
-    list(APPEND WPEBACKEND_FDO_PUBLIC_HEADERS include/wpe-fdo/view-backend-exportable-egl.h)
-    list(APPEND WPEBACKEND_FDO_SOURCES src/view-backend-exportable-fdo-egl.cpp)
-endif ()
 
 add_library(WPEBackend-fdo SHARED ${WPEBACKEND_FDO_SOURCES})
 target_include_directories(WPEBackend-fdo PRIVATE ${WPEBACKEND_FDO_INCLUDE_DIRECTORIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_compile_definitions(
     WPE_FDO_COMPILATION
     G_LOG_DOMAIN=\"WPE-FDO\"
     _FILE_OFFSET_BITS=64
+    _LARGEFILE64_SOURCE=1
 )
 
 configure_file(include/wpe-fdo/version.h.cmake "${CMAKE_BINARY_DIR}/version.h" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,11 @@ find_package(Wayland REQUIRED client server egl)
 find_package(WaylandScanner REQUIRED)
 find_package(WPE 1.5.90 REQUIRED)
 
-add_definitions(-DWPE_FDO_COMPILATION -DG_LOG_DOMAIN=\"WPE-FDO\")
+add_compile_definitions(
+    WPE_FDO_COMPILATION
+    G_LOG_DOMAIN=\"WPE-FDO\"
+    _FILE_OFFSET_BITS=64
+)
 
 configure_file(include/wpe-fdo/version.h.cmake "${CMAKE_BINARY_DIR}/version.h" @ONLY)
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -1,0 +1,1 @@
+# API Reference

--- a/meson.build
+++ b/meson.build
@@ -90,6 +90,7 @@ unstable_api_headers = [
 add_project_arguments(
 	'-DWPE_FDO_COMPILATION=1',
 	'-DG_LOG_DOMAIN="WPE-FDO"',
+	'-D_LARGEFILE64_SOURCE=1',
 	language: ['c', 'cpp']
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,265 @@
+project('WPEBackend-fdo', ['c', 'cpp'],
+	meson_version: '>=0.49',
+	default_options: [
+		'b_ndebug=if-release',
+		'c_std=c99',
+		'cpp_eh=none',
+		'cpp_std=c++11',
+	],
+	license: 'BSD-2-Clause',
+	version: '1.7.0',
+)
+
+# This refers to the API level provided. This is modified only with major,
+# breaking changes, which need modifications in programs using the library
+# before they can be compiled again.
+api_version = '1.0'
+
+# Before making a release, the soversion array should be modified.
+# The string is of the form [C, R, A].
+# - If interfaces have been changed or added, but binary compatibility has
+#   been preserved, change to [C+1, 0, A+1].
+# - If binary compatibility has been broken (eg removed or changed interfaces)
+#   change to [C+1, 0, 0]
+# - If the interface is the same as the previous version, use [C, R+1, A].
+soversion = [7, 0, 6]
+
+# Split the *project* version into its components.
+version_info = meson.project_version().split('.')
+version_info = {
+	'PROJECT_VERSION_MAJOR': version_info[0],
+	'PROJECT_VERSION_MINOR': version_info[1],
+	'PROJECT_VERSION_PATCH': version_info[2],
+}
+
+# Mangle [C, R, A] into an actual usable *soversion*.
+soversion_major = soversion[0] - soversion[2]  # Current-Age
+soversion_minor = soversion[2]  # Age
+soversion_micro = soversion[1]  # Revision
+soversion = '@0@.@1@.@2@'.format(soversion_major, soversion_minor, soversion_micro)
+
+sources = [
+	'src/exported-buffer-shm.cpp',
+	'src/exported-image-egl.cpp',
+	'src/fdo.cpp',
+	'src/initialize-egl.cpp',
+	'src/initialize-shm.cpp',
+	'src/ipc.cpp',
+	'src/renderer-backend-egl.cpp',
+	'src/renderer-host.cpp',
+	'src/version.c',
+	'src/view-backend-exportable-fdo.cpp',
+	'src/view-backend-exportable-fdo-egl.cpp',
+	'src/view-backend-exportable-private.cpp',
+	'src/ws.cpp',
+	'src/ws-client.cpp',
+	'src/ws-egl.cpp',
+	'src/ws-shm.cpp',
+	'src/extensions/video-plane-display-dmabuf.cpp',
+	'src/extensions/video-plane-display-dmabuf-receiver.cpp',
+	'src/linux-dmabuf/linux-dmabuf.cpp',
+	'src/linux-dmabuf/linux-dmabuf-protocol.c',
+]
+
+api_headers = [
+	'include/wpe-fdo/exported-image-egl.h',
+	'include/wpe-fdo/exported-buffer-shm.h',
+	'include/wpe-fdo/initialize-egl.h',
+	'include/wpe-fdo/view-backend-exportable.h',
+	'include/wpe-fdo/view-backend-exportable-egl.h',
+	'include/wpe-fdo/fdo-egl.h',
+	'include/wpe-fdo/fdo.h',
+
+	# Generated API headers.
+	configure_file(
+		input: 'include/wpe-fdo/version.h.cmake',
+		output: 'version.h',
+		configuration: version_info,
+	),
+]
+
+extensions_api_headers = [
+	'include/wpe-fdo/extensions/video-plane-display-dmabuf.h',
+]
+
+unstable_api_headers = [
+	'include/wpe-fdo/unstable/fdo-shm.h',
+	'include/wpe-fdo/unstable/initialize-shm.h',
+]
+
+add_project_arguments(
+	'-DWPE_FDO_COMPILATION=1',
+	'-DG_LOG_DOMAIN="WPE-FDO"',
+	language: ['c', 'cpp']
+)
+
+wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
+if wayland_scanner_dep.found()
+	wayland_scanner = find_program(
+		wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
+		native: true
+	)
+else
+	wayland_scanner = find_program('wayland-scanner', native: true)
+endif
+
+r = run_command(wayland_scanner, '--version')
+assert(r.returncode() == 0,
+	'''Cannot execute wayland-scanner:
+	''' + r.stderr())
+wayland_scanner_version = r.stderr().split()
+if not (wayland_scanner_version.length() == 2)
+	wayland_scanner_version = r.stdout().split()
+endif
+wayland_scanner_code = 'code'
+if wayland_scanner_version.length() == 2
+	wayland_scanner_version = wayland_scanner_version[1]
+	if wayland_scanner_version.version_compare('>=1.15')
+		wayland_scanner_code = 'private-code'
+	endif
+	message('wayland-scanner version: ' + wayland_scanner_version)
+else
+	wayland_scanner_version = ''
+	message('wayland-scanner version: unknown')
+endif
+message('Using "' + wayland_scanner_code + '" as parameter to wayland-scanner')
+
+# Wayland extension: WPE bridge.
+wpe_bridge_client_proto_header = custom_target(
+	'wpe-bridge-client-proto-header',
+	input: 'src/bridge/wpe-bridge.xml',
+	output: '@BASENAME@-client-protocol.h',
+	command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_bridge_server_proto_header = custom_target(
+	'wpe-bridge-server-proto-header',
+	input: 'src/bridge/wpe-bridge.xml',
+	output: '@BASENAME@-server-protocol.h',
+	command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_bridge_proto_source = custom_target(
+	'wpe-bridge-proto-source',
+	input: 'src/bridge/wpe-bridge.xml',
+	output: '@BASENAME@-protocol.c',
+	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
+)
+
+# Wayland extension: DMA-BUF video plane display.
+wpe_video_plane_display_dmabuf_client_proto_header = custom_target(
+	'video-plane-display-dmabuf-client-proto-header',
+	input: 'src/extensions/wpe-video-plane-display-dmabuf.xml',
+	output: '@BASENAME@-client-protocol.h',
+	command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_video_plane_display_dmabuf_server_proto_header = custom_target(
+	'video-plane-display-dmabuf-server-proto-header',
+	input: 'src/extensions/wpe-video-plane-display-dmabuf.xml',
+	output: '@BASENAME@-server-protocol.h',
+	command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_video_plane_display_dmabuf_proto_source = custom_target(
+	'video-plane-display-dmabuf-proto-source',
+	input: 'src/extensions/wpe-video-plane-display-dmabuf.xml',
+	output: '@BASENAME@-protocol.c',
+	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
+)
+
+cxx = meson.get_compiler('cpp')
+
+# Switch to the 'cpp_eh=none' default option when updating to Meson 0.51 or newer, see
+# https://mesonbuild.com/Builtin-options.html
+if meson.version().version_compare('<0.51')
+	add_project_arguments(
+		cxx.get_supported_arguments(['-fno-exceptions']),
+		language: 'cpp'
+	)
+endif
+
+# Switch to the 'cpp_rtti=false' default option when updating to Meson 0.53 or newer, see
+# https://mesonbuild.com/FAQ.html#how-do-i-disable-exceptions-and-rtti-in-my-c-project
+if meson.version().version_compare('<0.53')
+	add_project_arguments(
+		cxx.get_supported_arguments(['-fno-rtti']),
+		language: 'cpp'
+	)
+endif
+
+add_project_arguments(
+	cxx.get_supported_arguments(['-fvisibility=hidden']),
+	language: 'cpp'
+)
+add_project_arguments(
+	meson.get_compiler('c').get_supported_arguments(['-fvisibility=hidden']),
+	language: 'c'
+)
+
+deps = [
+	dependency('epoxy'),
+	dependency('gio-2.0'),
+	dependency('gobject-2.0'),
+	dependency('wayland-client'),
+	dependency('wayland-server'),
+	dependency('wayland-egl'),
+	dependency('wpe-1.0', version: '>=1.5.90'),
+]
+
+xkbcommon_dep = dependency('xkbcommon', required: false)
+if xkbcommon_dep.found()
+	deps += [xkbcommon_dep]
+elif not cxx.has_header('xkbcommon/xkbcommon-keysyms.h')
+	error('The <xkbcommon/xkbcommon-keysyms.h> header is missing')
+endif
+
+lib = shared_library(meson.project_name() + '-' + api_version,
+	sources,
+	wpe_bridge_proto_source,
+	wpe_bridge_client_proto_header,
+	wpe_bridge_server_proto_header,
+	wpe_video_plane_display_dmabuf_proto_source,
+	wpe_video_plane_display_dmabuf_client_proto_header,
+	wpe_video_plane_display_dmabuf_server_proto_header,
+	install: true,
+	dependencies: deps,
+	version: soversion,
+	soversion: soversion_major,
+	include_directories: include_directories('include'),
+)
+
+install_headers(api_headers,
+	subdir: join_paths('wpe-fdo-' + api_version, 'wpe'),
+)
+install_headers(extensions_api_headers,
+	subdir: join_paths('wpe-fdo-' + api_version, 'wpe', 'extensions'),
+)
+install_headers(unstable_api_headers,
+	subdir: join_paths('wpe-fdo-' + api_version, 'wpe', 'unstable'),
+)
+
+import('pkgconfig').generate(
+	description: 'The WPEBackend-fdo library',
+	name: 'wpebackend-fdo-' + api_version,
+	subdirs: 'wpe-fdo-' + api_version,
+	libraries: lib,
+	version: meson.project_version(),
+)
+
+if get_option('build_docs')
+	hotdoc = import('hotdoc')
+	assert(hotdoc.has_extensions('c-extension'),
+		'The HotDoc C extension is required.'
+	)
+	libwpe_doc = hotdoc.generate_doc(meson.project_name(),
+		project_version: api_version,
+		index: 'docs/index.markdown',
+		sitemap: 'docs/sitemap.txt',
+		console: true,
+		install: true,
+		build_by_default: true,
+		c_smart_index: true,
+		c_sources: api_headers,
+		c_include_directories: ['include', meson.current_build_dir()],
+		# The space here is relevant, see
+		# https://github.com/mesonbuild/meson/issues/5800#issuecomment-552198354
+		extra_c_flags: [' -DWPE_FDO_COMPILATION=1'],
+	)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('build_docs',
+	type: 'boolean',
+	value: false,
+	description: 'Build reference documentation (needs HotDoc)')

--- a/src/extensions/video-plane-display-dmabuf-receiver.cpp
+++ b/src/extensions/video-plane-display-dmabuf-receiver.cpp
@@ -25,7 +25,7 @@
 
 #include "wpe-fdo/extensions/video-plane-display-dmabuf.h"
 
-#include "ws.h"
+#include "../ws.h"
 #include <unistd.h>
 
 static struct {

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -25,8 +25,8 @@
 
 #include "wpe-fdo/extensions/video-plane-display-dmabuf.h"
 
-#include "video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-client-protocol.h"
-#include "ws-client.h"
+#include "wpe-video-plane-display-dmabuf-client-protocol.h"
+#include "../ws-client.h"
 #include <wpe/wpe-egl.h>
 #include <cstring>
 

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -32,6 +32,7 @@ namespace FdoIPC {
 
 class MessageReceiver {
 public:
+    virtual ~MessageReceiver() = default;
     virtual void didReceiveMessage(uint32_t messageId, uint32_t messageBody) = 0;
 };
 

--- a/src/linux-dmabuf/linux-dmabuf.cpp
+++ b/src/linux-dmabuf/linux-dmabuf.cpp
@@ -6,7 +6,7 @@
 #include <assert.h>
 #include "linux-dmabuf.h"
 #include "linux-dmabuf-unstable-v1-server-protocol.h"
-#include "ws-egl.h"
+#include "../ws-egl.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/version.c
+++ b/src/version.c
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe-fdo/version.h"
+#include "version.h"
 
 __attribute__((visibility("default")))
 unsigned

--- a/src/ws-client.h
+++ b/src/ws-client.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "bridge/wpe-bridge-client-protocol.h"
+#include "wpe-bridge-client-protocol.h"
 #include "ipc.h"
 #include <glib.h>
 #include <wayland-client.h>

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -25,8 +25,8 @@
 
 #include "ws.h"
 
-#include "bridge/wpe-bridge-server-protocol.h"
-#include "video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-server-protocol.h"
+#include "wpe-bridge-server-protocol.h"
+#include "wpe-video-plane-display-dmabuf-server-protocol.h"
 #include <cassert>
 #include <sys/socket.h>
 #include <unistd.h>

--- a/src/ws.h
+++ b/src/ws.h
@@ -37,6 +37,7 @@ struct wpe_video_plane_display_dmabuf_export;
 namespace WS {
 
 struct ExportableClient {
+    virtual ~ExportableClient() = default;
     virtual void frameCallback(struct wl_resource*) = 0;
     virtual void exportBufferResource(struct wl_resource*) = 0;
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;


### PR DESCRIPTION
I did this just as a proof of concept to see what it would take to migrate a CMake project to Meson, now that Buildroot has some support upstream for Meson — Feel free to skip merging this PR, or defer it for later, but personally I find Meson the less annoying of the existing configuration/build systems so my personal opinion is that this is a change for better :wink: 