### PR TITLE
wl improvements

### DIFF
--- a/src/renderer-backend-egl.cpp
+++ b/src/renderer-backend-egl.cpp
@@ -127,6 +127,8 @@ public:
             g_mutex_unlock(&m_threading.mutex);
         }
 
+        wl_compositor_destroy(m_compositor);
+        wl_registry_destroy(m_registry);
         wl_display_disconnect(m_display);
     }
 

--- a/src/renderer-backend-egl.cpp
+++ b/src/renderer-backend-egl.cpp
@@ -97,6 +97,10 @@ public:
     {
         m_display = wl_display_connect_to_fd(hostFd);
 
+        m_registry = wl_display_get_registry(m_display);
+        wl_registry_add_listener(m_registry, &s_registryListener, this);
+        wl_display_roundtrip(m_display);
+
         g_mutex_init(&m_threading.mutex);
         g_cond_init(&m_threading.cond);
         {
@@ -183,10 +187,6 @@ gpointer Backend::s_threadFunc(gpointer data)
         g_source_set_priority(backend.m_threading.source, -70);
         g_source_set_can_recurse(backend.m_threading.source, TRUE);
         g_source_attach(backend.m_threading.source, backend.m_threading.context);
-
-        backend.m_registry = wl_display_get_registry(backend.m_display);
-        wl_registry_add_listener(backend.m_registry, &s_registryListener, &backend);
-        wl_display_roundtrip(backend.m_display);
 
         g_cond_signal(&backend.m_threading.cond);
         g_mutex_unlock(&backend.m_threading.mutex);

--- a/src/renderer-backend-egl.cpp
+++ b/src/renderer-backend-egl.cpp
@@ -122,6 +122,8 @@ public:
 
             g_mutex_unlock(&m_threading.mutex);
         }
+
+        wl_display_disconnect(m_display);
     }
 
     struct wl_display* display() const { return m_display; }

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -118,17 +118,20 @@ public:
         for (auto* resource : m_callbackResources)
             wl_callback_send_done(resource, 0);
         m_callbackResources.clear();
+        wl_client_flush(m_client);
     }
 
     void releaseBuffer(struct wl_resource* buffer_resource)
     {
         wl_buffer_send_release(buffer_resource);
+        wl_client_flush(m_client);
     }
 
 private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_id { 0 };
+    struct wl_client* m_client { nullptr };
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
@@ -154,7 +157,7 @@ gboolean ViewBackend::s_socketCallback(GSocket* socket, GIOCondition condition, 
     if (len == sizeof(uint32_t) * 2 && message[0] == 0x42) {
         auto& viewBackend = *static_cast<ViewBackend*>(data);
         viewBackend.m_id = message[1];
-        WS::Instance::singleton().registerViewBackend(viewBackend.m_id, viewBackend);
+        viewBackend.m_client = WS::Instance::singleton().registerViewBackend(viewBackend.m_id, viewBackend);
     }
 
     return TRUE;

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -83,6 +83,8 @@ GSourceFuncs Source::s_sourceFuncs = {
 
 struct Surface {
     uint32_t id { 0 };
+    struct wl_client* client { nullptr };
+
     ExportableClient* exportableClient { nullptr };
 
     struct wl_resource* bufferResource { nullptr };
@@ -153,6 +155,7 @@ static const struct wl_compositor_interface s_compositorInterface = {
         }
 
         auto* surface = new Surface;
+        surface->client = client;
         surface->id = id;
         Instance::singleton().createSurface(id, surface);
         wl_resource_set_implementation(surfaceResource, &s_surfaceInterface, surface,
@@ -242,13 +245,14 @@ void Instance::createSurface(uint32_t id, Surface* surface)
     m_viewBackendMap.insert({ id, surface });
 }
 
-void Instance::registerViewBackend(uint32_t id, ExportableClient& exportableClient)
+struct wl_client* Instance::registerViewBackend(uint32_t id, ExportableClient& exportableClient)
 {
     auto it = m_viewBackendMap.find(id);
     if (it == m_viewBackendMap.end())
         std::abort();
 
     it->second->exportableClient = &exportableClient;
+    return it->second->client;
 }
 
 void Instance::unregisterViewBackend(uint32_t id)

--- a/src/ws.h
+++ b/src/ws.h
@@ -50,7 +50,7 @@ public:
     int createClient();
 
     void createSurface(uint32_t, Surface*);
-    void registerViewBackend(uint32_t, ExportableClient&);
+    struct wl_client* registerViewBackend(uint32_t, ExportableClient&);
     void unregisterViewBackend(uint32_t);
 
 private:


### PR DESCRIPTION
Move the Wayland connection handling into a separate thread.

Use a dedicated wl_event_queue for our operations on said Wayland connection.

Clean up all the Wayland resources in Backend destructor in renderer-backend-egl.

Flush the client after frame dispatch or buffer release commands are issued, immediately writing the messages to the display connection. 