### PR TITLE
Stop defining __u32 and __u64 as it might already be typedefed

### DIFF
--- a/src/linux-dmabuf/drm_fourcc.h
+++ b/src/linux-dmabuf/drm_fourcc.h
@@ -26,15 +26,12 @@
 
 #include <stdint.h>
 
-#define __u32 uint32_t
-#define __u64 uint64_t
-
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
-#define fourcc_code(a, b, c, d) ((__u32)(a) | ((__u32)(b) << 8) | \
-				 ((__u32)(c) << 16) | ((__u32)(d) << 24))
+#define fourcc_code(a, b, c, d) ((uint32_t)(a) | ((uint32_t)(b) << 8) | \
+				 ((uint32_t)(c) << 16) | ((uint32_t)(d) << 24))
 
 #define DRM_FORMAT_BIG_ENDIAN (1<<31) /* format is big endian instead of little endian */
 
@@ -191,7 +188,7 @@ extern "C" {
 #define DRM_FORMAT_RESERVED	      ((1ULL << 56) - 1)
 
 #define fourcc_mod_code(vendor, val) \
-	((((__u64)DRM_FORMAT_MOD_VENDOR_## vendor) << 56) | ((val) & 0x00ffffffffffffffULL))
+	((((uint32_t)DRM_FORMAT_MOD_VENDOR_## vendor) << 56) | ((val) & 0x00ffffffffffffffULL))
 
 /*
  * Format Modifier tokens:


### PR DESCRIPTION
Inside flatpak on aarch64 I am getting the following build failure:

```
In file included from /home/thiblahute/devel/Webkit/webkit-master/WebKitBuild/FlatpakCache/WPEBackend-fdo/src/linux-dmabuf/linux-dmabuf.h:15:0,
                 from /home/thiblahute/devel/Webkit/webkit-master/WebKitBuild/FlatpakCache/WPEBackend-fdo/src/view-backend-exportable-fdo-egl.cpp:26:
/home/thiblahute/devel/Webkit/webkit-master/WebKitBuild/FlatpakCache/WPEBackend-fdo/src/linux-dmabuf/drm_fourcc.h:30:15: error: conflicting declaration ‘typedef long long unsigned int uint64_t’
 #define __u64 uint64_t
               ^
In file included from /usr/lib/gcc/aarch64-unknown-linux/6.2.0/include/stdint.h:9:0,
                 from /home/thiblahute/devel/Webkit/webkit-master/WebKitBuild/FlatpakCache/WPEBackend-fdo/src/linux-dmabuf/linux-dmabuf.h:13,
                 from /home/thiblahute/devel/Webkit/webkit-master/WebKitBuild/FlatpakCache/WPEBackend-fdo/src/view-backend-exportable-fdo-egl.cpp:26:
/usr/include/stdint.h:55:27: note: previous declaration as ‘typedef long unsigned int uint64_t’
 typedef unsigned long int uint64_t;
                           ^~~~~~~~
make[2]: *** [CMakeFiles/WPEBackend-fdo.dir/build.make:279: CMakeFiles/WPEBackend-fdo.dir/src/view-backend-exportable-fdo-egl.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:132: CMakeFiles/WPEBackend-fdo.dir/all] Error 2
make: *** [Makefile:128: all] Error 2
```

I have to admit I didn't understand why those typedefs existed in the
first place.