### PR TITLE
Mark client struct parameters as const in _create() functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+=======================
+1.0.0 - August 21, 2018
+=======================
+
+- Updated to use libwpe 1.0.0.
+- The libWPEBackend-fdo library now uses the libtool versioning convention.
+- New API which supports exporting frames as EGL images. This provides
+  applications with a ready to to render EGLImage, and has the advantage
+  that the library hides the actual protocol used by the backend's nested
+  compositor from the application.
+- Improved dispatching of Wayland events.
+- Support using DMA-BUF Wayland surfaces.
+- Support using Wayland versions older than 1.10
+
+====================
 0.1 - April 26, 2018
 ====================
 

--- a/include/wpe-fdo/view-backend-exportable-egl.h
+++ b/include/wpe-fdo/view-backend-exportable-egl.h
@@ -49,7 +49,7 @@ struct wpe_view_backend_exportable_fdo_egl_client {
 };
 
 struct wpe_view_backend_exportable_fdo*
-wpe_view_backend_exportable_fdo_egl_create(struct wpe_view_backend_exportable_fdo_egl_client*, void*, uint32_t width, uint32_t height);
+wpe_view_backend_exportable_fdo_egl_create(const struct wpe_view_backend_exportable_fdo_egl_client*, void*, uint32_t width, uint32_t height);
 
 void
 wpe_view_backend_exportable_fdo_egl_dispatch_release_image(struct wpe_view_backend_exportable_fdo* exportable, EGLImageKHR image);

--- a/include/wpe-fdo/view-backend-exportable.h
+++ b/include/wpe-fdo/view-backend-exportable.h
@@ -48,7 +48,7 @@ struct wpe_view_backend_exportable_fdo_client {
 };
 
 struct wpe_view_backend_exportable_fdo*
-wpe_view_backend_exportable_fdo_create(struct wpe_view_backend_exportable_fdo_client*, void*, uint32_t width, uint32_t height);
+wpe_view_backend_exportable_fdo_create(const struct wpe_view_backend_exportable_fdo_client*, void*, uint32_t width, uint32_t height);
 
 void
 wpe_view_backend_exportable_fdo_destroy(struct wpe_view_backend_exportable_fdo*);

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -68,7 +68,7 @@ struct buffer_data {
 
 class ClientBundleEGL final : public ClientBundle {
 public:
-    ClientBundleEGL(struct wpe_view_backend_exportable_fdo_egl_client* _client, void* data,
+    ClientBundleEGL(const struct wpe_view_backend_exportable_fdo_egl_client* _client, void* data,
                     ViewBackend* viewBackend, uint32_t initialWidth, uint32_t initialHeight)
         : ClientBundle(data, viewBackend, initialWidth, initialHeight)
         , client(_client)
@@ -206,7 +206,7 @@ public:
         return nullptr;
     }
 
-    struct wpe_view_backend_exportable_fdo_egl_client* client;
+    const struct wpe_view_backend_exportable_fdo_egl_client* client;
 
 private:
     EGLDisplay m_eglDisplay;
@@ -222,7 +222,7 @@ extern "C" {
 
 __attribute__((visibility("default")))
 struct wpe_view_backend_exportable_fdo*
-wpe_view_backend_exportable_fdo_egl_create(struct wpe_view_backend_exportable_fdo_egl_client* client, void* data, uint32_t width, uint32_t height)
+wpe_view_backend_exportable_fdo_egl_create(const struct wpe_view_backend_exportable_fdo_egl_client* client, void* data, uint32_t width, uint32_t height)
 {
     auto* clientBundle = new ClientBundleEGL(client, data, nullptr, width, height);
 

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -31,7 +31,7 @@ namespace {
 
 class ClientBundleBuffer final : public ClientBundle {
 public:
-    ClientBundleBuffer(struct wpe_view_backend_exportable_fdo_client* _client, void* data, ViewBackend* viewBackend,
+    ClientBundleBuffer(const struct wpe_view_backend_exportable_fdo_client* _client, void* data, ViewBackend* viewBackend,
                  uint32_t initialWidth, uint32_t initialHeight)
         : ClientBundle(data, viewBackend, initialWidth, initialHeight)
         , client(_client)
@@ -50,7 +50,7 @@ public:
         assert(!"This interface doesn't support Linux DMA buffers");
     }
 
-    struct wpe_view_backend_exportable_fdo_client* client;
+    const struct wpe_view_backend_exportable_fdo_client* client;
 };
 
 } // namespace
@@ -59,7 +59,7 @@ extern "C" {
 
 __attribute__((visibility("default")))
 struct wpe_view_backend_exportable_fdo*
-wpe_view_backend_exportable_fdo_create(struct wpe_view_backend_exportable_fdo_client* client, void* data, uint32_t width, uint32_t height)
+wpe_view_backend_exportable_fdo_create(const struct wpe_view_backend_exportable_fdo_client* client, void* data, uint32_t width, uint32_t height)
 {
     auto* clientBundle = new ClientBundleBuffer(client, data, nullptr, width, height);
 


### PR DESCRIPTION
The client structs are used vtables, which in shouldn't change, so the parameters to the `*_create()` functions can be marked `const`.