### PR TITLE
Remove unneeded inclusion of the <wpe.h> header

### DIFF
--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -28,7 +28,6 @@
 #include <wayland-egl.h>
 
 #include <wpe/wpe-egl.h>
-#include <wpe/wpe.h>
 
 extern struct wpe_renderer_host_interface fdo_renderer_host;
 


### PR DESCRIPTION
The `<wpe-egl.h>` inclusion should take care itself of bringing in any other headers it may need. Indeed, including `<wpe.h>` is not needed after WebPlatformForEmbedded/libwpe#34 has been merged.