### PR TITLE
Clean up wl_callback resource in ViewBackend::dispatchFrameCallback()

### DIFF
--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -103,8 +103,10 @@ void ViewBackend::exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buf
 
 void ViewBackend::dispatchFrameCallback()
 {
-    for (auto* resource : m_callbackResources)
+    for (auto* resource : m_callbackResources) {
         wl_callback_send_done(resource, 0);
+        wl_resource_destroy(resource);
+    }
     m_callbackResources.clear();
     wl_client_flush(m_client);
     wpe_view_backend_dispatch_frame_displayed(m_backend);


### PR DESCRIPTION
After calling wl_callback_send_done(), the callback wl_resource object
must be destroyed. This effectively avoids leaking these objects.