### PR TITLE
ws: Fix build

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -30,6 +30,7 @@
 #include "linux-dmabuf/linux-dmabuf.h"
 #include "bridge/wpe-bridge-server-protocol.h"
 #include <cassert>
+#include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
 


### PR DESCRIPTION
string.h is needed for strlen() and strstr().