### PR TITLE
Add wpe_fdo_egl_exported_image struct to wrap the EGL image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(WPEBACKEND_FDO_LIBRARIES
 )
 
 set(WPEBACKEND_FDO_PUBLIC_HEADERS
+    include/wpe-fdo/exported-image-egl.h
     include/wpe-fdo/initialize-egl.h
     include/wpe-fdo/view-backend-exportable.h
     include/wpe-fdo/fdo-egl.h
@@ -74,6 +75,7 @@ set(WPEBACKEND_FDO_GENERATED_SOURCES
 set(WPEBACKEND_FDO_SOURCES
     ${WPEBACKEND_FDO_GENERATED_SOURCES}
 
+    src/exported-image-egl.cpp
     src/fdo.cpp
     src/initialize-egl.cpp
     src/renderer-backend-egl.cpp

--- a/include/wpe-fdo/exported-image-egl.h
+++ b/include/wpe-fdo/exported-image-egl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2019 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,34 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __WEBKIT_WEB_EXTENSION_H__
-#error "Headers <wpe/fdo-egl.h> and <wpe/webkit-web-extension.h> cannot be included together."
+#if !defined(__WPE_FDO_EGL_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/fdo-egl.h> can be included directly."
 #endif
 
-#ifndef __wpe_fdo_egl_h__
-#define __wpe_fdo_egl_h__
+#ifndef __exported_image_egl_h__
+#define __exported_image_egl_h__
 
-#define __WPE_FDO_EGL_H_INSIDE__
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
+#include <wpe/wpe.h>
 
-#undef __WPE_FDO_EGL_H_INSIDE__
+typedef void* EGLImageKHR;
 
-#endif /* __wpe_fdo_egl_h__ */
+struct wpe_fdo_egl_exported_image;
+
+uint32_t
+wpe_fdo_egl_exported_image_get_width(struct wpe_fdo_egl_exported_image*);
+
+uint32_t
+wpe_fdo_egl_exported_image_get_height(struct wpe_fdo_egl_exported_image*);
+
+EGLImageKHR
+wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __exported_image_egl_h___ */

--- a/include/wpe-fdo/view-backend-exportable-egl.h
+++ b/include/wpe-fdo/view-backend-exportable-egl.h
@@ -40,12 +40,14 @@ typedef void* EGLImageKHR;
 
 struct wpe_view_backend_exportable_fdo;
 
+struct wpe_fdo_egl_exported_image;
+
 struct wpe_view_backend_exportable_fdo_egl_client {
     void (*export_egl_image)(void* data, EGLImageKHR image);
+    void (*export_fdo_egl_image)(void* data, struct wpe_fdo_egl_exported_image* image);
     void (*_wpe_reserved0)(void);
     void (*_wpe_reserved1)(void);
     void (*_wpe_reserved2)(void);
-    void (*_wpe_reserved3)(void);
 };
 
 struct wpe_view_backend_exportable_fdo*
@@ -53,6 +55,9 @@ wpe_view_backend_exportable_fdo_egl_create(const struct wpe_view_backend_exporta
 
 void
 wpe_view_backend_exportable_fdo_egl_dispatch_release_image(struct wpe_view_backend_exportable_fdo* exportable, EGLImageKHR image);
+
+void
+wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(struct wpe_view_backend_exportable_fdo*, struct wpe_fdo_egl_exported_image*);
 
 #ifdef __cplusplus
 }

--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2019 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,42 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __WEBKIT_WEB_EXTENSION_H__
-#error "Headers <wpe/fdo-egl.h> and <wpe/webkit-web-extension.h> cannot be included together."
-#endif
+#include "view-backend-exportable-fdo-egl-private.h"
+#include "ws.h"
+#include <cassert>
+#include <wpe-fdo/exported-image-egl.h>
 
-#ifndef __wpe_fdo_egl_h__
-#define __wpe_fdo_egl_h__
+extern "C" {
 
-#define __WPE_FDO_EGL_H_INSIDE__
+__attribute__((visibility("default")))
+uint32_t
+wpe_fdo_egl_exported_image_get_width(struct wpe_fdo_egl_exported_image* image)
+{
+    return image->width;
+}
 
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
+__attribute__((visibility("default")))
+uint32_t
+wpe_fdo_egl_exported_image_get_height(struct wpe_fdo_egl_exported_image* image)
+{
+    return image->height;
+}
 
-#undef __WPE_FDO_EGL_H_INSIDE__
+__attribute__((visibility("default")))
+EGLImageKHR
+wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image* image)
+{
+    return image->eglImage;
+}
 
-#endif /* __wpe_fdo_egl_h__ */
+}
+
+void
+wpe_fdo_egl_exported_image_destroy(struct wpe_fdo_egl_exported_image* image)
+{
+    assert(image->eglImage);
+    WS::Instance::singleton().destroyImage(image->eglImage);
+    wl_list_remove(&image->bufferDestroyListener.link);
+
+    delete image;
+}

--- a/src/view-backend-exportable-fdo-egl-private.h
+++ b/src/view-backend-exportable-fdo-egl-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2019 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __WEBKIT_WEB_EXTENSION_H__
-#error "Headers <wpe/fdo-egl.h> and <wpe/webkit-web-extension.h> cannot be included together."
-#endif
+#pragma once
 
-#ifndef __wpe_fdo_egl_h__
-#define __wpe_fdo_egl_h__
+#include <wayland-server.h>
 
-#define __WPE_FDO_EGL_H_INSIDE__
+typedef void *EGLImageKHR;
 
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
+struct wpe_fdo_egl_exported_image {
+    EGLImageKHR eglImage { nullptr };
+    uint32_t width { 0 };
+    uint32_t height { 0 };
+    bool locked { false };
+    struct wl_resource* bufferResource { nullptr };
+    struct wl_listener bufferDestroyListener;
+};
 
-#undef __WPE_FDO_EGL_H_INSIDE__
-
-#endif /* __wpe_fdo_egl_h__ */
+void wpe_fdo_egl_exported_image_destroy(struct wpe_fdo_egl_exported_image*);

--- a/src/ws.h
+++ b/src/ws.h
@@ -66,6 +66,8 @@ public:
     EGLImageKHR createImage(const struct linux_dmabuf_buffer*);
     void destroyImage(EGLImageKHR);
 
+    void queryBufferSize(struct wl_resource*, uint32_t* width, uint32_t* height);
+
     void importDmaBufBuffer(struct linux_dmabuf_buffer*);
     const struct linux_dmabuf_buffer* getDmaBufBuffer(struct wl_resource*) const;
     void foreachDmaBufModifier(std::function<void (int format, uint64_t modifier)>);


### PR DESCRIPTION
A new vfunc has been added to wpe_view_backend_exportable_fdo_egl_client
that receives a struct wpe_fdo_egl_exported_image. The image is
created associated to its buffer resource, and released when the buffer
is destroyed if the user released it back.