### PR TITLE
Do not include egl.h in public headers

### DIFF
--- a/include/wpe-fdo/initialize-egl.h
+++ b/include/wpe-fdo/initialize-egl.h
@@ -34,8 +34,9 @@
 extern "C" {
 #endif
 
-#include <EGL/egl.h>
 #include <stdbool.h>
+
+typedef void *EGLDisplay;
 
 bool
 wpe_fdo_initialize_for_egl_display(EGLDisplay);


### PR DESCRIPTION
It includes eglplatform that cand end up including Xlib.h.