### PR TITLE
Handle the case of new target created for the same view backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(WPEBACKEND_FDO_SOURCES
     src/exported-image-egl.cpp
     src/fdo.cpp
     src/initialize-egl.cpp
+    src/ipc.cpp
     src/renderer-backend-egl.cpp
     src/renderer-host.cpp
     src/view-backend-exportable-fdo.cpp

--- a/src/ipc-messages.h
+++ b/src/ipc-messages.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace FdoIPC {
+
+enum Messages {
+    RegisterSurface = 0x42,
+    UnregisterSurface = 0x43,
+};
+
+} // namespace FdoIPC

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ipc.h"
+#include <cstdio>
+
+namespace FdoIPC {
+
+static const size_t messageSize = 2 * sizeof(uint32_t);
+
+std::unique_ptr<Connection> Connection::create(int fd, MessageReceiver* messageReceiver)
+{
+    GError* error = nullptr;
+    auto* socket = g_socket_new_from_fd(fd, &error);
+    if (!socket) {
+        fprintf(stderr, "WPE fdo failed to create socket for fd %d: %s", fd, error->message);
+        g_error_free(error);
+
+        return nullptr;
+    }
+
+    return std::unique_ptr<Connection>(new Connection(socket, messageReceiver));
+}
+
+Connection::Connection(GSocket* socket, MessageReceiver* messageReceiver)
+    : m_socket(socket)
+    , m_messageReceiver(messageReceiver)
+{
+    g_socket_set_blocking(m_socket, FALSE);
+
+    if (m_messageReceiver) {
+        m_socketSource = g_socket_create_source(m_socket, G_IO_IN, nullptr);
+        g_source_set_name(m_socketSource, "WPEBackend-fdo::socket");
+        g_source_set_callback(m_socketSource, reinterpret_cast<GSourceFunc>(s_socketCallback), this, nullptr);
+        g_source_attach(m_socketSource, g_main_context_get_thread_default());
+    }
+}
+
+Connection::~Connection()
+{
+    if (m_socketSource) {
+        g_source_destroy(m_socketSource);
+        g_source_unref(m_socketSource);
+    }
+    g_clear_object(&m_socket);
+}
+
+void Connection::send(uint32_t messageId, uint32_t messageBody)
+{
+    GError* error = nullptr;
+    uint32_t message[2] = { messageId, messageBody };
+    gssize len = g_socket_send(m_socket, reinterpret_cast<gchar*>(message), messageSize, nullptr, &error);
+    if (len == -1) {
+        fprintf(stderr, "WPE fdo failed to send message %u to socket: %s", messageId, error->message);
+        g_error_free(error);
+    }
+}
+
+gboolean Connection::s_socketCallback(GSocket* socket, GIOCondition condition, gpointer data)
+{
+    if (!(condition & G_IO_IN))
+                return TRUE;
+
+    GError* error = nullptr;
+    uint32_t message[2];
+    gssize len = g_socket_receive(socket, reinterpret_cast<gchar*>(message), messageSize, nullptr, &error);
+    if (len == -1) {
+        fprintf(stderr, "WPE fdo failed to read message from socket: %s", error->message);
+        g_error_free(error);
+        return FALSE;
+    }
+
+    if (len != messageSize)
+        return TRUE;
+
+    static_cast<Connection*>(data)->m_messageReceiver->didReceiveMessage(message[0], message[1]);
+    return TRUE;
+}
+
+} // namespace FdoIPC

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <memory>
+
+namespace FdoIPC {
+
+class MessageReceiver {
+public:
+    virtual void didReceiveMessage(uint32_t messageId, uint32_t messageBody) = 0;
+};
+
+class Connection {
+public:
+    static std::unique_ptr<Connection> create(int fd, MessageReceiver* = nullptr);
+
+    Connection(GSocket*, MessageReceiver*);
+    ~Connection();
+
+    void send(uint32_t messageId, uint32_t messageBody);
+
+private:
+    static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
+
+    GSocket* m_socket { nullptr };
+    MessageReceiver* m_messageReceiver { nullptr };
+    GSource* m_socketSource { nullptr };
+};
+
+} // namespace FdoIPC

--- a/src/renderer-backend-egl.cpp
+++ b/src/renderer-backend-egl.cpp
@@ -139,6 +139,11 @@ public:
 
     ~Target()
     {
+        if (m_wl.wpeBridgeId && m_glib.socket) {
+            uint32_t message[] = { 0x43, m_wl.wpeBridgeId };
+            g_socket_send(m_glib.socket, reinterpret_cast<gchar*>(message), 2 * sizeof(uint32_t), nullptr, nullptr);
+        }
+
         g_clear_pointer(&m_wl.frameCallback, wl_callback_destroy);
         g_clear_pointer(&m_wl.window, wl_egl_window_destroy);
         g_clear_pointer(&m_wl.surface, wl_surface_destroy);
@@ -223,6 +228,7 @@ public:
 
     void bridgeConnected(uint32_t bridgeID)
     {
+        m_wl.wpeBridgeId = bridgeID;
         uint32_t message[] = { 0x42, bridgeID };
         if (m_glib.socket)
             g_socket_send(m_glib.socket, reinterpret_cast<gchar*>(message), 2 * sizeof(uint32_t), nullptr, nullptr);
@@ -246,11 +252,11 @@ private:
     } m_glib;
 
     struct {
-        struct wl_display* displayWrapper { nullptr };
         struct wl_event_queue* eventQueue { nullptr };
         struct wl_registry* registry { nullptr };
         struct wl_compositor* compositor { nullptr };
         struct wpe_bridge* wpeBridge { nullptr };
+        uint32_t wpeBridgeId { 0 };
 
         struct wl_surface* surface { nullptr };
         struct wl_egl_window* window { nullptr };

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ipc.h"
 #include "ws.h"
 #include <gio/gio.h>
 #include <vector>
@@ -53,7 +54,7 @@ public:
     uint32_t initialHeight;
 };
 
-class ViewBackend : public WS::ExportableClient {
+class ViewBackend : public WS::ExportableClient, public FdoIPC::MessageReceiver {
 public:
     ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* backend);
     ~ViewBackend();
@@ -67,6 +68,8 @@ public:
     void releaseBuffer(struct wl_resource* buffer_resource);
 
 private:
+    void didReceiveMessage(uint32_t messageId, uint32_t messageBody) override;
+
     void registerSurface(uint32_t);
     void unregisterSurface(uint32_t);
 
@@ -80,8 +83,7 @@ private:
 
     std::vector<struct wl_resource*> m_callbackResources;
 
-    GSocket* m_socket;
-    GSource* m_source;
+    std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
 };
 

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -67,9 +67,12 @@ public:
     void releaseBuffer(struct wl_resource* buffer_resource);
 
 private:
+    void registerSurface(uint32_t);
+    void unregisterSurface(uint32_t);
+
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
-    uint32_t m_id { 0 };
+    uint32_t m_surfaceId { 0 };
     struct wl_client* m_client { nullptr };
 
     ClientBundle* m_clientBundle;

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -231,7 +231,7 @@ static const struct wpe_bridge_interface s_wpeBridgeInterface = {
         static uint32_t bridgeID = 0;
         ++bridgeID;
         wpe_bridge_send_connected(resource, bridgeID);
-        Instance::singleton().createSurface(bridgeID, surface);
+        Instance::singleton().registerSurface(bridgeID, surface);
     },
 };
 
@@ -393,7 +393,7 @@ int Instance::createClient()
     return clientFd;
 }
 
-void Instance::createSurface(uint32_t id, Surface* surface)
+void Instance::registerSurface(uint32_t id, Surface* surface)
 {
     m_viewBackendMap.insert({ id, surface });
 }
@@ -538,9 +538,9 @@ void Instance::foreachDmaBufModifier(std::function<void (int format, uint64_t mo
     }
 }
 
-struct wl_client* Instance::registerViewBackend(uint32_t id, ExportableClient& exportableClient)
+struct wl_client* Instance::registerViewBackend(uint32_t surfaceId, ExportableClient& exportableClient)
 {
-    auto it = m_viewBackendMap.find(id);
+    auto it = m_viewBackendMap.find(surfaceId);
     if (it == m_viewBackendMap.end())
         std::abort();
 
@@ -548,9 +548,9 @@ struct wl_client* Instance::registerViewBackend(uint32_t id, ExportableClient& e
     return it->second->client;
 }
 
-void Instance::unregisterViewBackend(uint32_t id)
+void Instance::unregisterViewBackend(uint32_t surfaceId)
 {
-    auto it = m_viewBackendMap.find(id);
+    auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->exportableClient = nullptr;
         m_viewBackendMap.erase(it);

--- a/src/ws.h
+++ b/src/ws.h
@@ -53,7 +53,7 @@ public:
 
     int createClient();
 
-    void createSurface(uint32_t, Surface*);
+    void registerSurface(uint32_t, Surface*);
     struct wl_client* registerViewBackend(uint32_t, ExportableClient&);
     void unregisterViewBackend(uint32_t);
 


### PR DESCRIPTION
The client can remove a target and create a new one for the same view
backend. In that case we need to unregister the current view backend in
the wayland compositor before registering the one. This patch renames
WS::Instance::createSurface as registerSurface to clarify that it's not
creating a new surface but registering a new one for the given id. Also
ViewBackend::m_id has been renamed as m_surfaceId to clarify that's not
the backend identifier, but the current surface identifier.