### PR TITLE
linux-dmabuf: adjust fourcc_mod_code macro's shifted-to value's type …

### DIFF
--- a/src/linux-dmabuf/drm_fourcc.h
+++ b/src/linux-dmabuf/drm_fourcc.h
@@ -188,7 +188,7 @@ extern "C" {
 #define DRM_FORMAT_RESERVED	      ((1ULL << 56) - 1)
 
 #define fourcc_mod_code(vendor, val) \
-	((((uint32_t)DRM_FORMAT_MOD_VENDOR_## vendor) << 56) | ((val) & 0x00ffffffffffffffULL))
+	((((uint64_t)DRM_FORMAT_MOD_VENDOR_## vendor) << 56) | ((val) & 0x00ffffffffffffffULL))
 
 /*
  * Format Modifier tokens:


### PR DESCRIPTION
…to uint64_t.