### PR TITLE
linux-dmabuf fixes

### DIFF
--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -152,6 +152,7 @@ public:
 
         auto* image = new struct wpe_fdo_egl_exported_image;
         image->eglImage = eglImage;
+        image->bufferResource = dmabufBuffer->buffer_resource;
         image->width = dmabufBuffer->attributes.width;
         image->height = dmabufBuffer->attributes.height;
         wl_list_init(&image->bufferDestroyListener.link);

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -177,13 +177,13 @@ static const struct wl_surface_interface s_surfaceInterface = {
         if (!surface.exportableClient)
             return;
 
-        if (surface.dmabufBuffer) {
+        struct wl_resource* bufferResource = surface.bufferResource;
+        surface.bufferResource = nullptr;
+
+        if (surface.dmabufBuffer)
             surface.exportableClient->exportLinuxDmabuf(surface.dmabufBuffer);
-        } else {
-            struct wl_resource* bufferResource = surface.bufferResource;
-            surface.bufferResource = nullptr;
+        else
             surface.exportableClient->exportBufferResource(bufferResource);
-        }
     },
     // set_buffer_transform
     [](struct wl_client*, struct wl_resource*, int32_t) { },


### PR DESCRIPTION
1) compiler warning fix, changes the target type in the fourcc_mod_code macro to uint64_t. Replicates https://gitlab.freedesktop.org/mesa/drm/commit/b3c4c79e16f13a72e8124f69453a37135329f968.

2) One step to avoiding early releases of dmabuf-related wl_resources that can then cause tearing. If not nulled out here (like it's done for basic wl_resources), then the early release happens as soon as the next buffer is attached (see the attach implementation).