### PR TITLE
wpe_fdo_egl_exported_image: add destroy-notify callback support.

### DIFF
--- a/include/wpe-fdo/exported-image-egl.h
+++ b/include/wpe-fdo/exported-image-egl.h
@@ -40,6 +40,11 @@ typedef void* EGLImageKHR;
 
 struct wpe_fdo_egl_exported_image;
 
+typedef void (*wpe_fdo_egl_exported_image_destroy_notify_t)(void *data, struct wpe_fdo_egl_exported_image *image);
+
+void
+wpe_fdo_egl_exported_image_set_destroy_notify(struct wpe_fdo_egl_exported_image*, wpe_fdo_egl_exported_image_destroy_notify_t, void*);
+
 uint32_t
 wpe_fdo_egl_exported_image_get_width(struct wpe_fdo_egl_exported_image*);
 

--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -31,6 +31,14 @@
 extern "C" {
 
 __attribute__((visibility("default")))
+void
+wpe_fdo_egl_exported_image_set_destroy_notify(struct wpe_fdo_egl_exported_image* image, wpe_fdo_egl_exported_image_destroy_notify_t destroyNotify, void* destroyData)
+{
+    image->destroyNotify = destroyNotify;
+    image->destroyData = destroyData;
+}
+
+__attribute__((visibility("default")))
 uint32_t
 wpe_fdo_egl_exported_image_get_width(struct wpe_fdo_egl_exported_image* image)
 {
@@ -56,6 +64,9 @@ wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image* imag
 void
 wpe_fdo_egl_exported_image_destroy(struct wpe_fdo_egl_exported_image* image)
 {
+    if (image->destroyNotify)
+        image->destroyNotify(image->destroyData, image);
+
     assert(image->eglImage);
     WS::Instance::singleton().destroyImage(image->eglImage);
     wl_list_remove(&image->bufferDestroyListener.link);

--- a/src/view-backend-exportable-fdo-egl-private.h
+++ b/src/view-backend-exportable-fdo-egl-private.h
@@ -29,6 +29,8 @@
 
 typedef void *EGLImageKHR;
 
+typedef void (*wpe_fdo_egl_exported_image_destroy_notify_t)(void* data, struct wpe_fdo_egl_exported_image *image);
+
 struct wpe_fdo_egl_exported_image {
     EGLImageKHR eglImage { nullptr };
     uint32_t width { 0 };
@@ -36,6 +38,9 @@ struct wpe_fdo_egl_exported_image {
     bool locked { false };
     struct wl_resource* bufferResource { nullptr };
     struct wl_listener bufferDestroyListener;
+
+    wpe_fdo_egl_exported_image_destroy_notify_t destroyNotify;
+    void* destroyData;
 };
 
 void wpe_fdo_egl_exported_image_destroy(struct wpe_fdo_egl_exported_image*);


### PR DESCRIPTION
This should allow caching and subsequently safely destroying relevant
resources in user-facing applications.