### PR TITLE
fdo.h: Include local version.h header

### DIFF
--- a/include/wpe-fdo/fdo.h
+++ b/include/wpe-fdo/fdo.h
@@ -32,7 +32,7 @@
 
 #define __WPE_FDO_H_INSIDE__
 
-#include <wpe/version.h>
+#include "version.h"
 #include <wpe/view-backend-exportable.h>
 
 #undef __WPE_FDO_H_INSIDE__


### PR DESCRIPTION
<wpe/version.h> is also a libwpe header, so to avoid an include conflict, use a
quoted include instead of a bracket include.