### PR TITLE
Rename the EGL members (for 1.2)

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -70,11 +70,11 @@ typedef EGLBoolean (* PFNEGLQUERYDMABUFMODIFIERSEXTPROC) (EGLDisplay dpy, EGLint
 #define EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT 0x344A
 #endif /* EGL_EXT_image_dma_buf_import_modifiers */
 
-static PFNEGLBINDWAYLANDDISPLAYWL eglBindWaylandDisplayWL;
-static PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
-static PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
-static PFNEGLQUERYDMABUFFORMATSEXTPROC eglQueryDmaBufFormatsEXT;
-static PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT;
+static PFNEGLBINDWAYLANDDISPLAYWL s_eglBindWaylandDisplayWL;
+static PFNEGLCREATEIMAGEKHRPROC s_eglCreateImageKHR;
+static PFNEGLDESTROYIMAGEKHRPROC s_eglDestroyImageKHR;
+static PFNEGLQUERYDMABUFFORMATSEXTPROC s_eglQueryDmaBufFormatsEXT;
+static PFNEGLQUERYDMABUFMODIFIERSEXTPROC s_eglQueryDmaBufModifiersEXT;
 
 namespace WS {
 
@@ -343,18 +343,21 @@ bool Instance::initialize(EGLDisplay eglDisplay)
 
     const char* extensions = eglQueryString(eglDisplay, EGL_EXTENSIONS);
     if (isEGLExtensionSupported(extensions, "EGL_WL_bind_wayland_display"))
-        eglBindWaylandDisplayWL = reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(eglGetProcAddress("eglBindWaylandDisplayWL"));
-    if (!eglBindWaylandDisplayWL)
+        s_eglBindWaylandDisplayWL = reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(eglGetProcAddress("eglBindWaylandDisplayWL"));
+        assert(s_eglBindWaylandDisplayWL);
+    if (!s_eglBindWaylandDisplayWL)
         return false;
 
     if (isEGLExtensionSupported(extensions, "EGL_KHR_image_base")) {
-        eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
-        eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
+        s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
+        assert(s_eglCreateImageKHR);
+        s_eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
+        assert(s_eglDestroyImageKHR);
     }
-    if (!eglCreateImageKHR || !eglDestroyImageKHR)
+    if (!s_eglCreateImageKHR || !s_eglDestroyImageKHR)
         return false;
 
-    if (!eglBindWaylandDisplayWL(eglDisplay, m_display))
+    if (!s_eglBindWaylandDisplayWL(eglDisplay, m_display))
         return false;
 
     m_eglDisplay = eglDisplay;
@@ -362,10 +365,12 @@ bool Instance::initialize(EGLDisplay eglDisplay)
     /* Initialize Linux dmabuf subsystem. */
     if (isEGLExtensionSupported(extensions, "EGL_EXT_image_dma_buf_import")
         && isEGLExtensionSupported(extensions, "EGL_EXT_image_dma_buf_import_modifiers")) {
-        eglQueryDmaBufFormatsEXT = reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(eglGetProcAddress("eglQueryDmaBufFormatsEXT"));
-        eglQueryDmaBufModifiersEXT = reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(eglGetProcAddress("eglQueryDmaBufModifiersEXT"));
+        s_eglQueryDmaBufFormatsEXT = reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(eglGetProcAddress("eglQueryDmaBufFormatsEXT"));
+        assert(s_eglQueryDmaBufFormatsEXT);
+        s_eglQueryDmaBufModifiersEXT = reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(eglGetProcAddress("eglQueryDmaBufModifiersEXT"));
+        assert(s_eglQueryDmaBufModifiersEXT);
     }
-    if (eglQueryDmaBufFormatsEXT && eglQueryDmaBufModifiersEXT) {
+    if (s_eglQueryDmaBufFormatsEXT && s_eglQueryDmaBufModifiersEXT) {
         if (m_linuxDmabuf)
             assert(!"Linux-dmabuf has already been initialized");
         m_linuxDmabuf = linux_dmabuf_setup(m_display);
@@ -399,7 +404,7 @@ EGLImageKHR Instance::createImage(struct wl_resource* resourceBuffer)
 {
     if (m_eglDisplay == EGL_NO_DISPLAY)
         return EGL_NO_IMAGE_KHR;
-    return eglCreateImageKHR(m_eglDisplay, EGL_NO_CONTEXT, EGL_WAYLAND_BUFFER_WL, resourceBuffer, nullptr);
+    return s_eglCreateImageKHR(m_eglDisplay, EGL_NO_CONTEXT, EGL_WAYLAND_BUFFER_WL, resourceBuffer, nullptr);
 }
 
 EGLImageKHR Instance::createImage(const struct linux_dmabuf_buffer* dmabufBuffer)
@@ -460,14 +465,14 @@ EGLImageKHR Instance::createImage(const struct linux_dmabuf_buffer* dmabufBuffer
 
     attribs[atti++] = EGL_NONE;
 
-    return eglCreateImageKHR(m_eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attribs);
+    return s_eglCreateImageKHR(m_eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attribs);
 }
 
 void Instance::destroyImage(EGLImageKHR image)
 {
     if (m_eglDisplay == EGL_NO_DISPLAY)
         return;
-    eglDestroyImageKHR(m_eglDisplay, image);
+    s_eglDestroyImageKHR(m_eglDisplay, image);
 }
 
 void Instance::importDmaBufBuffer(struct linux_dmabuf_buffer* buffer)
@@ -498,13 +503,13 @@ void Instance::foreachDmaBufModifier(std::function<void (int format, uint64_t mo
 
     EGLint formats[128];
     EGLint numFormats;
-    if (!eglQueryDmaBufFormatsEXT(m_eglDisplay, 128, formats, &numFormats))
+    if (!s_eglQueryDmaBufFormatsEXT(m_eglDisplay, 128, formats, &numFormats))
         assert(!"Linux-dmabuf: Failed to query formats");
 
     for (int i = 0; i < numFormats; i++) {
         uint64_t modifiers[64];
         EGLint numModifiers;
-        if (!eglQueryDmaBufModifiersEXT(m_eglDisplay, formats[i], 64, modifiers, NULL, &numModifiers))
+        if (!s_eglQueryDmaBufModifiersEXT(m_eglDisplay, formats[i], 64, modifiers, NULL, &numModifiers))
             assert(!"Linux-dmabuf: Failed to query modifiers of a format");
 
         /* Send DRM_FORMAT_MOD_INVALID token when no modifiers are supported


### PR DESCRIPTION
Renaming of the egl... members as s_ avoiding identifiers in our code
clashing with official names of functions is definitely a good idea to
avoid redeclaration errors like this:

  src/ws.cpp:74:33: error: 'void* (* eglCreateImageKHR)(EGLDisplay,
  EGLContext, EGLenum, EGLClientBuffer, const EGLint*)' redeclared as
  different kind of symbol
  static PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;

The argument to eglGetProcAddress() has nothing to do with the name of
the variable. It is the name of a symbol from the EGL API:
<https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglGetProcAddress.xhtml>.

Also added non-null asserts to those pointers to make more evident
crashes due to null in the future (for example: changes in the name of
the symbols):

    assert(s_eglBindWaylandDisplayWL);
    assert(s_eglCreateImageKHR);
    assert(s_eglDestroyImageKHR);
    assert(s_eglQueryDmaBufFormatsEXT);
    assert(s_eglQueryDmaBufModifiersEXT);