### PR TITLE
ws: Include stdio.h before using stderr

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -30,6 +30,7 @@
 #include "linux-dmabuf/linux-dmabuf.h"
 #include "bridge/wpe-bridge-server-protocol.h"
 #include <cassert>
+#include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>


### PR DESCRIPTION
It fixes the build on FreeBSD.
```
[11/16] Building CXX object CMakeFiles/WPEBackend-fdo.dir/src/ws.cpp.o
FAILED: CMakeFiles/WPEBackend-fdo.dir/src/ws.cpp.o 
/usr/bin/clang++  -B/home/lantw44/.local/bin  -DWAYLAND_1_10_OR_GREATER -DWPEBackend_fdo_EXPORTS -DWPE_FDO_COMPILATION -D_THREAD_SAFE -I../include -I. -I../src -I/home/lantw44/gnome/devinstall/include/glib-2.0 -I/home/lantw44/gnome/devinstall/lib/glib-2.0/include -I/home/lantw44/gnome/devinstall/include/wpe-1.0 -march=corei7 -B/home/lantw44/.local/bin -pipe -g3 -O0 -gz -fdebug-macro -std=c++11 -fno-exceptions -fno-rtti -fPIC   -pthread -MD -MT CMakeFiles/WPEBackend-fdo.dir/src/ws.cpp.o -MF CMakeFiles/WPEBackend-fdo.dir/src/ws.cpp.o.d -o CMakeFiles/WPEBackend-fdo.dir/src/ws.cpp.o -c ../src/ws.cpp
../src/ws.cpp:341:17: error: use of undeclared identifier 'stderr'
        fprintf(stderr, "WPE fdo doesn't support multiple EGL displays\n");
                ^
1 error generated.
```