### PR TITLE
Support linux-dmabuf exports in wpe_view_backend_exportable_fdo_client

### DIFF
--- a/include/wpe-fdo/view-backend-exportable.h
+++ b/include/wpe-fdo/view-backend-exportable.h
@@ -39,9 +39,21 @@ extern "C" {
 struct wl_resource;
 struct wpe_view_backend_exportable_fdo;
 
+struct wpe_view_backend_exportable_fdo_dmabuf_resource {
+    struct wl_resource* buffer_resource;
+    uint32_t width;
+    uint32_t height;
+    uint32_t format;
+    uint8_t n_planes;
+    int32_t fds[4];
+    uint32_t strides[4];
+    uint32_t offsets[4];
+    uint64_t modifiers[4];
+};
+
 struct wpe_view_backend_exportable_fdo_client {
     void (*export_buffer_resource)(void* data, struct wl_resource* buffer_resource);
-    void (*_wpe_reserved0)(void);
+    void (*export_dmabuf_resource)(void* data, struct wpe_view_backend_exportable_fdo_dmabuf_resource* dmabuf_resource);
     void (*_wpe_reserved1)(void);
     void (*_wpe_reserved2)(void);
     void (*_wpe_reserved3)(void);

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -47,7 +47,25 @@ public:
 
     void exportBuffer(const struct linux_dmabuf_buffer *dmabuf_buffer) override
     {
-        assert(!"This interface doesn't support Linux DMA buffers");
+        auto* attributes = &dmabuf_buffer->attributes;
+
+        struct wpe_view_backend_exportable_fdo_dmabuf_resource dmabuf_resource;
+        memset(&dmabuf_resource, 0, sizeof(struct wpe_view_backend_exportable_fdo_dmabuf_resource));
+        dmabuf_resource.buffer_resource = dmabuf_buffer->buffer_resource;
+        dmabuf_resource.width = attributes->width;
+        dmabuf_resource.height = attributes->height;
+        dmabuf_resource.format = attributes->format;
+
+        if (attributes->n_planes >= 0)
+            dmabuf_resource.n_planes = attributes->n_planes;
+        for (uint8_t i = 0; i < dmabuf_resource.n_planes; ++i) {
+            dmabuf_resource.fds[i] = attributes->fd[i];
+            dmabuf_resource.strides[i] = attributes->stride[i];
+            dmabuf_resource.offsets[i] = attributes->offset[i];
+            dmabuf_resource.modifiers[i] = attributes->modifier[i];
+        }
+
+        client->export_dmabuf_resource(data, &dmabuf_resource);
     }
 
     const struct wpe_view_backend_exportable_fdo_client* client;


### PR DESCRIPTION
Add the export_dmabuf_resource callback to the
wpe_view_backend_exportable_fdo_client interface. This callback provides an
wpe_view_backend_exportable_fdo_dmabuf_resource object that describes the
linux-dmabuf resource that's being exported.

The originating wl_resource is included in this new descriptor struct in order
to enable the application to release the resource through the existing
wpe_view_backend_exportable_fdo_dispatch_release_buffer() API. Other members of
the descriptor struct provide all the available information about the dmabuf
to enable reusing it through various other APIs like libgbm.