### PR TITLE
Arrange passing -Wall, check whether used compiler flags are supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,27 @@ CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(LIBWPEBACKEND_FDO 4 0 3)
 
 project(wpebackend-fdo VERSION "${PROJECT_VERSION}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-exceptions -fno-rtti")
-
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 include(DistTargets)
 include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
+
+foreach (cxxflag -fno-exceptions -fno-rtti -Wall)
+    check_cxx_compiler_flag("${cxxflag}" CXX_HAS_FLAG_${cxxflag})
+    if (CXX_HAS_FLAG_${cxxflag})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${cxxflag}")
+    endif ()
+endforeach ()
+
+foreach (cflag -Wall)
+    check_c_compiler_flag("${cflag}" CC_HAS_FLAG_${cflag})
+    if (CC_HAS_FLAG_${cflag})
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${cflag}")
+    endif ()
+endforeach ()
 
 find_package(EGL REQUIRED)
 find_package(GLIB REQUIRED COMPONENTS gio)

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -54,7 +54,7 @@ public:
     uint32_t initialHeight;
 };
 
-class ViewBackend : public WS::ExportableClient, public FdoIPC::MessageReceiver {
+class ViewBackend final : public WS::ExportableClient, public FdoIPC::MessageReceiver {
 public:
     ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* backend);
     ~ViewBackend();


### PR DESCRIPTION
The first commit arranges passing `-Wall` to the compiler, checking whether compiler flags are supported before adding them to the set of used ones, and using CMake's built-in C/C++ standard selection smarts. The second adds `final` to declarations to avoid a compiler warning (and it is good practice, too).