### PR TITLE
Fix -Wdelete-non-virtual-dtor warning

### DIFF
--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -57,7 +57,7 @@ public:
 class ViewBackend : public WS::ExportableClient, public FdoIPC::MessageReceiver {
 public:
     ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* backend);
-    ~ViewBackend();
+    virtual ~ViewBackend();
 
     void initialize();
     int clientFd();


### PR DESCRIPTION
This was detected because a downstream manually adds -Wall to its build
flags. WPEBackend-fdo should consider turning on at least -Wall.

Note there is no functional bug here because ViewBackend is the
most-derived class being deleted, but this is certainly fragile.