### PR TITLE
Use int as the file descriptor type

### DIFF
--- a/include/wpe-fdo/view-backend-exportable.h
+++ b/include/wpe-fdo/view-backend-exportable.h
@@ -45,7 +45,7 @@ struct wpe_view_backend_exportable_fdo_dmabuf_resource {
     uint32_t height;
     uint32_t format;
     uint8_t n_planes;
-    int32_t fds[4];
+    int fds[4];
     uint32_t strides[4];
     uint32_t offsets[4];
     uint64_t modifiers[4];

--- a/src/linux-dmabuf/linux-dmabuf.cpp
+++ b/src/linux-dmabuf/linux-dmabuf.cpp
@@ -21,7 +21,7 @@ params_destroy(struct wl_client *client, struct wl_resource *resource)
 static void
 params_add(struct wl_client *client,
 	   struct wl_resource *params_resource,
-	   int32_t name_fd,
+	   int name_fd,
 	   uint32_t plane_idx,
 	   uint32_t offset,
 	   uint32_t stride,

--- a/src/linux-dmabuf/linux-dmabuf.h
+++ b/src/linux-dmabuf/linux-dmabuf.h
@@ -16,7 +16,7 @@ struct linux_dmabuf_attributes {
     uint32_t format;
     uint32_t flags; /* enum zlinux_buffer_params_flags */
     int8_t n_planes;
-    int32_t fd[MAX_DMABUF_PLANES];
+    int fd[MAX_DMABUF_PLANES];
     uint32_t offset[MAX_DMABUF_PLANES];
     uint32_t stride[MAX_DMABUF_PLANES];
     uint64_t modifier[MAX_DMABUF_PLANES];


### PR DESCRIPTION
Convert back from int32_t to simply int when storing file descriptor values,
conforming to the usual Linux standards for this topic.