### PR TITLE
wl_resource management fixes

### DIFF
--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -52,13 +52,3 @@ wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image* imag
 }
 
 }
-
-void
-wpe_fdo_egl_exported_image_destroy(struct wpe_fdo_egl_exported_image* image)
-{
-    assert(image->eglImage);
-    WS::Instance::singleton().destroyImage(image->eglImage);
-    wl_list_remove(&image->bufferDestroyListener.link);
-
-    delete image;
-}

--- a/src/view-backend-exportable-fdo-egl-private.h
+++ b/src/view-backend-exportable-fdo-egl-private.h
@@ -33,9 +33,7 @@ struct wpe_fdo_egl_exported_image {
     EGLImageKHR eglImage { nullptr };
     uint32_t width { 0 };
     uint32_t height { 0 };
-    bool locked { false };
+    bool exported { false };
     struct wl_resource* bufferResource { nullptr };
     struct wl_listener bufferDestroyListener;
 };
-
-void wpe_fdo_egl_exported_image_destroy(struct wpe_fdo_egl_exported_image*);

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -36,9 +36,14 @@ namespace {
 
 class ClientBundleEGLDeprecated final : public ClientBundle {
 public:
-    struct buffer_data {
-        struct wl_resource *buffer_resource;
-        EGLImageKHR egl_image;
+    struct BufferResource {
+        struct wl_resource* resource;
+        EGLImageKHR image;
+
+        struct wl_list link;
+        struct wl_listener destroyListener;
+
+        static void destroyNotify(struct wl_listener*, void*);
     };
 
     ClientBundleEGLDeprecated(const struct wpe_view_backend_exportable_fdo_egl_client* _client, void* data,
@@ -46,29 +51,37 @@ public:
         : ClientBundle(data, viewBackend, initialWidth, initialHeight)
         , client(_client)
     {
+        wl_list_init(&bufferResources);
     }
 
     virtual ~ClientBundleEGLDeprecated()
     {
-        for (auto* buf_data : m_buffers) {
-            assert(buf_data->egl_image);
-            WS::Instance::singleton().destroyImage(buf_data->egl_image);
+        BufferResource* resource;
+        BufferResource* next;
+        wl_list_for_each_safe(resource, next, &bufferResources, link) {
+            WS::Instance::singleton().destroyImage(resource->image);
+            viewBackend->releaseBuffer(resource->resource);
 
-            delete buf_data;
+            wl_list_remove(&resource->link);
+            wl_list_remove(&resource->destroyListener.link);
+            delete resource;
         }
-        m_buffers.clear();
+        wl_list_init(&bufferResources);
     }
 
-    void exportBuffer(struct wl_resource *bufferResource) override
+    void exportBuffer(struct wl_resource *buffer) override
     {
-        EGLImageKHR image = WS::Instance::singleton().createImage(bufferResource);
+        EGLImageKHR image = WS::Instance::singleton().createImage(buffer);
         if (!image)
             return;
 
-        auto* buf_data = new struct buffer_data;
-        buf_data->buffer_resource = bufferResource;
-        buf_data->egl_image = image;
-        m_buffers.push_back(buf_data);
+        auto* resource = new BufferResource;
+        resource->resource = buffer;
+        resource->image = image;
+        resource->destroyListener.notify = BufferResource::destroyNotify;
+
+        wl_resource_add_destroy_listener(buffer, &resource->destroyListener);
+        wl_list_insert(&bufferResources, &resource->link);
 
         client->export_egl_image(data, image);
     }
@@ -79,32 +92,52 @@ public:
         if (!image)
             return;
 
-        auto* buf_data = new struct buffer_data;
-        buf_data->buffer_resource = dmabuf_buffer->buffer_resource;
-        buf_data->egl_image = image;
-        m_buffers.push_back(buf_data);
+        auto* resource = new BufferResource;
+        resource->resource = dmabuf_buffer->buffer_resource;
+        resource->image = image;
+        resource->destroyListener.notify = BufferResource::destroyNotify;
+
+        wl_resource_add_destroy_listener(dmabuf_buffer->buffer_resource, &resource->destroyListener);
+        wl_list_insert(&bufferResources, &resource->link);
 
         client->export_egl_image(data, image);
     }
 
-    struct buffer_data* releaseImage(EGLImageKHR image)
+    void releaseImage(EGLImageKHR image)
     {
-        for (auto* buf_data : m_buffers)
-            if (buf_data->egl_image == image) {
-                m_buffers.remove(buf_data);
-                WS::Instance::singleton().destroyImage(buf_data->egl_image);
-
-                return buf_data;
+        BufferResource* matchingResource = nullptr;
+        BufferResource* resource;
+        wl_list_for_each(resource, &bufferResources, link) {
+            if (resource->image == image) {
+                matchingResource = resource;
+                break;
             }
+        }
 
-        return nullptr;
+        WS::Instance::singleton().destroyImage(image);
+
+        if (matchingResource) {
+            viewBackend->releaseBuffer(matchingResource->resource);
+
+            wl_list_remove(&matchingResource->link);
+            wl_list_remove(&matchingResource->destroyListener.link);
+            delete matchingResource;
+        }
     }
 
     const struct wpe_view_backend_exportable_fdo_egl_client* client;
 
-private:
-    std::list<struct buffer_data*> m_buffers;
+    struct wl_list bufferResources;
 };
+
+void ClientBundleEGLDeprecated::BufferResource::destroyNotify(struct wl_listener* listener, void*)
+{
+    BufferResource* resource;
+    resource = wl_container_of(listener, resource, destroyListener);
+
+    wl_list_remove(&resource->link);
+    delete resource;
+}
 
 class ClientBundleEGL final : public ClientBundle {
 public:
@@ -220,20 +253,7 @@ __attribute__((visibility("default")))
 void
 wpe_view_backend_exportable_fdo_egl_dispatch_release_image(struct wpe_view_backend_exportable_fdo* exportable, EGLImageKHR image)
 {
-    auto* clientBundle = reinterpret_cast<ClientBundleEGLDeprecated*>(exportable->clientBundle);
-
-    auto* buffer_data = clientBundle->releaseImage(image);
-    if (!buffer_data)
-        return;
-
-    /* the EGL image has already been destroyed by ClientBundleEGL */
-
-    if (buffer_data->buffer_resource) {
-        wpe_view_backend_exportable_fdo_dispatch_release_buffer(exportable,
-                                                                buffer_data->buffer_resource);
-    }
-
-    delete buffer_data;
+    static_cast<ClientBundleEGLDeprecated*>(exportable->clientBundle)->releaseImage(image);
 }
 
 __attribute__((visibility("default")))

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -110,7 +110,7 @@ __attribute__((visibility("default")))
 void
 wpe_view_backend_exportable_fdo_dispatch_frame_complete(struct wpe_view_backend_exportable_fdo* exportable)
 {
-    exportable->clientBundle->viewBackend->dispatchFrameCallback();
+    exportable->clientBundle->viewBackend->dispatchFrameCallbacks();
 }
 
 __attribute__((visibility("default")))

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -32,18 +32,47 @@ namespace {
 
 class ClientBundleBuffer final : public ClientBundle {
 public:
+    struct BufferResource {
+        struct wl_resource* resource;
+
+        struct wl_list link;
+        struct wl_listener destroyListener;
+
+        static void destroyNotify(struct wl_listener*, void*);
+    };
+
     ClientBundleBuffer(const struct wpe_view_backend_exportable_fdo_client* _client, void* data, ViewBackend* viewBackend,
                  uint32_t initialWidth, uint32_t initialHeight)
         : ClientBundle(data, viewBackend, initialWidth, initialHeight)
         , client(_client)
     {
+        wl_list_init(&bufferResources);
     }
 
-    virtual ~ClientBundleBuffer() = default;
-
-    void exportBuffer(struct wl_resource *bufferResource) override
+    virtual ~ClientBundleBuffer()
     {
-        client->export_buffer_resource(data, bufferResource);
+        BufferResource* resource;
+        BufferResource* next;
+        wl_list_for_each_safe(resource, next, &bufferResources, link) {
+            viewBackend->releaseBuffer(resource->resource);
+
+            wl_list_remove(&resource->link);
+            wl_list_remove(&resource->destroyListener.link);
+            delete resource;
+        }
+        wl_list_init(&bufferResources);
+    }
+
+    void exportBuffer(struct wl_resource *buffer) override
+    {
+        auto* resource = new BufferResource;
+        resource->resource = buffer;
+        resource->destroyListener.notify = BufferResource::destroyNotify;
+
+        wl_resource_add_destroy_listener(buffer, &resource->destroyListener);
+        wl_list_insert(&bufferResources, &resource->link);
+
+        client->export_buffer_resource(data, buffer);
     }
 
     void exportBuffer(const struct linux_dmabuf_buffer *dmabuf_buffer) override
@@ -66,11 +95,50 @@ public:
             dmabuf_resource.modifiers[i] = attributes->modifier[i];
         }
 
+        auto* resource = new BufferResource;
+        resource->resource = dmabuf_buffer->buffer_resource;
+        resource->destroyListener.notify = BufferResource::destroyNotify;
+
+        wl_resource_add_destroy_listener(dmabuf_buffer->buffer_resource, &resource->destroyListener);
+        wl_list_insert(&bufferResources, &resource->link);
+
         client->export_dmabuf_resource(data, &dmabuf_resource);
     }
 
+    void releaseBuffer(struct wl_resource* buffer)
+    {
+        BufferResource* matchingResource = nullptr;
+        BufferResource* resource;
+        wl_list_for_each(resource, &bufferResources, link) {
+            if (resource->resource == buffer) {
+                matchingResource = resource;
+                break;
+            }
+        }
+
+        if (!matchingResource)
+            return;
+
+        viewBackend->releaseBuffer(buffer);
+
+        wl_list_remove(&matchingResource->link);
+        wl_list_remove(&matchingResource->destroyListener.link);
+        delete matchingResource;
+    }
+
     const struct wpe_view_backend_exportable_fdo_client* client;
+
+    struct wl_list bufferResources;
 };
+
+void ClientBundleBuffer::BufferResource::destroyNotify(struct wl_listener* listener, void*)
+{
+    BufferResource* resource;
+    resource = wl_container_of(listener, resource, destroyListener);
+
+    wl_list_remove(&resource->link);
+    delete resource;
+}
 
 } // namespace
 
@@ -115,9 +183,9 @@ wpe_view_backend_exportable_fdo_dispatch_frame_complete(struct wpe_view_backend_
 
 __attribute__((visibility("default")))
 void
-wpe_view_backend_exportable_fdo_dispatch_release_buffer(struct wpe_view_backend_exportable_fdo* exportable, struct wl_resource* buffer_resource)
+wpe_view_backend_exportable_fdo_dispatch_release_buffer(struct wpe_view_backend_exportable_fdo* exportable, struct wl_resource* buffer)
 {
-    exportable->clientBundle->viewBackend->releaseBuffer(buffer_resource);
+    static_cast<ClientBundleBuffer*>(exportable->clientBundle)->releaseBuffer(buffer);
 }
 
 }

--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -34,10 +34,14 @@ ViewBackend::ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* ba
     , m_backend(backend)
 {
     m_clientBundle->viewBackend = this;
+
+    wl_list_init(&m_frameCallbacks);
 }
 
 ViewBackend::~ViewBackend()
 {
+    clearFrameCallbacks();
+
     unregisterSurface(m_surfaceId);
 
     if (m_clientFd != -1)
@@ -72,7 +76,11 @@ int ViewBackend::clientFd()
 
 void ViewBackend::frameCallback(struct wl_resource* callback)
 {
-    m_frameCallbacks.push_back(callback);
+    auto* resource = new FrameCallbackResource;
+    resource->resource = callback;
+    resource->destroyListener.notify = FrameCallbackResource::destroyNotify;
+    wl_resource_add_destroy_listener(callback, &resource->destroyListener);
+    wl_list_insert(&m_frameCallbacks, &resource->link);
 }
 
 void ViewBackend::exportBufferResource(struct wl_resource* bufferResource)
@@ -87,11 +95,12 @@ void ViewBackend::exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buf
 
 void ViewBackend::dispatchFrameCallbacks()
 {
-    for (auto* resource : m_frameCallbacks) {
-        wl_callback_send_done(resource, 0);
-        wl_resource_destroy(resource);
+    FrameCallbackResource* resource;
+    wl_list_for_each(resource, &m_frameCallbacks, link) {
+        wl_callback_send_done(resource->resource, 0);
     }
-    m_frameCallbacks.clear();
+    clearFrameCallbacks();
+
     wl_client_flush(m_client);
     wpe_view_backend_dispatch_frame_displayed(m_backend);
 }
@@ -113,9 +122,7 @@ void ViewBackend::unregisterSurface(uint32_t surfaceId)
     if (!surfaceId || m_surfaceId != surfaceId)
         return;
 
-    for (auto* resource : m_frameCallbacks)
-        wl_resource_destroy(resource);
-    m_frameCallbacks.clear();
+    clearFrameCallbacks();
 
     WS::Instance::singleton().unregisterViewBackend(m_surfaceId);
     m_surfaceId = 0;
@@ -133,4 +140,26 @@ void ViewBackend::didReceiveMessage(uint32_t messageId, uint32_t messageBody)
     default:
         assert(!"WPE fdo received an invalid IPC message");
     }
+}
+
+void ViewBackend::clearFrameCallbacks()
+{
+    FrameCallbackResource* resource;
+    FrameCallbackResource* next;
+    wl_list_for_each_safe(resource, next, &m_frameCallbacks, link) {
+        wl_list_remove(&resource->link);
+        wl_list_remove(&resource->destroyListener.link);
+        wl_resource_destroy(resource->resource);
+        delete resource;
+    }
+    wl_list_init(&m_frameCallbacks);
+}
+
+void ViewBackend::FrameCallbackResource::destroyNotify(struct wl_listener* listener, void*)
+{
+    FrameCallbackResource* resource;
+    resource = wl_container_of(listener, resource, destroyListener);
+
+    wl_list_remove(&resource->link);
+    delete resource;
 }

--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -70,9 +70,9 @@ int ViewBackend::clientFd()
     return dup(m_clientFd);
 }
 
-void ViewBackend::frameCallback(struct wl_resource* callbackResource)
+void ViewBackend::frameCallback(struct wl_resource* callback)
 {
-    m_callbackResources.push_back(callbackResource);
+    m_frameCallbacks.push_back(callback);
 }
 
 void ViewBackend::exportBufferResource(struct wl_resource* bufferResource)
@@ -85,13 +85,13 @@ void ViewBackend::exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buf
     m_clientBundle->exportBuffer(dmabuf_buffer);
 }
 
-void ViewBackend::dispatchFrameCallback()
+void ViewBackend::dispatchFrameCallbacks()
 {
-    for (auto* resource : m_callbackResources) {
+    for (auto* resource : m_frameCallbacks) {
         wl_callback_send_done(resource, 0);
         wl_resource_destroy(resource);
     }
-    m_callbackResources.clear();
+    m_frameCallbacks.clear();
     wl_client_flush(m_client);
     wpe_view_backend_dispatch_frame_displayed(m_backend);
 }
@@ -113,9 +113,9 @@ void ViewBackend::unregisterSurface(uint32_t surfaceId)
     if (!surfaceId || m_surfaceId != surfaceId)
         return;
 
-    for (auto* resource : m_callbackResources)
+    for (auto* resource : m_frameCallbacks)
         wl_resource_destroy(resource);
-    m_callbackResources.clear();
+    m_frameCallbacks.clear();
 
     WS::Instance::singleton().unregisterViewBackend(m_surfaceId);
     m_surfaceId = 0;

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -28,7 +28,6 @@
 #include "ipc.h"
 #include "ws.h"
 #include <gio/gio.h>
-#include <vector>
 #include <wpe-fdo/view-backend-exportable.h>
 
 class ViewBackend;
@@ -68,10 +67,21 @@ public:
     void releaseBuffer(struct wl_resource* buffer_resource);
 
 private:
+    struct FrameCallbackResource {
+        struct wl_resource* resource;
+
+        struct wl_list link;
+        struct wl_listener destroyListener;
+
+        static void destroyNotify(struct wl_listener*, void*);
+    };
+
     void didReceiveMessage(uint32_t messageId, uint32_t messageBody) override;
 
     void registerSurface(uint32_t);
     void unregisterSurface(uint32_t);
+
+    void clearFrameCallbacks();
 
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
@@ -81,7 +91,7 @@ private:
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
 
-    std::vector<struct wl_resource*> m_frameCallbacks;
+    struct wl_list m_frameCallbacks;
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -64,7 +64,7 @@ public:
     void frameCallback(struct wl_resource* callbackResource) override;
     void exportBufferResource(struct wl_resource* bufferResource) override;
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
-    void dispatchFrameCallback();
+    void dispatchFrameCallbacks();
     void releaseBuffer(struct wl_resource* buffer_resource);
 
 private:
@@ -81,7 +81,7 @@ private:
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
 
-    std::vector<struct wl_resource*> m_callbackResources;
+    std::vector<struct wl_resource*> m_frameCallbacks;
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };


### PR DESCRIPTION
This tries to do a better job of tracking wl_resource lifetime and managing the resource release process in cases where the wl_resource was already destroyed.