### PR TITLE
CMake: Avoid target_link_libraries() with imported targets

### DIFF
--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -51,7 +51,8 @@ mark_as_advanced(EGL_INCLUDE_DIR EGL_LIBRARY)
 if (EGL_LIBRARIES AND NOT TARGET GL::egl)
     add_library(GL::egl INTERFACE IMPORTED)
     if (TARGET PkgConfig::EGL)
-        target_link_libraries(GL::egl INTERFACE PkgConfig::EGL)
+        set_property(TARGET GL::egl PROPERTY
+            INTERFACE_LINK_LIBRARIES PkgConfig::EGL)
     else ()
         set_property(TARGET GL::egl PROPERTY
             INTERFACE_LINK_LIBRARIES ${EGL_LIBRARY})

--- a/cmake/FindWPE.cmake
+++ b/cmake/FindWPE.cmake
@@ -48,7 +48,8 @@ mark_as_advanced(WPE_INCLUDE_DIR WPE_LIBRARY)
 if (WPE_LIBRARY AND NOT TARGET WPE::libwpe)
     add_library(WPE::libwpe INTERFACE IMPORTED)
     if (TARGET PkgConfig::WPE)
-        target_link_libraries(WPE::libwpe INTERFACE PkgConfig::WPE)
+        set_property(TARGET WPE::libwpe PROPERTY
+            INTERFACE_LINK_LIBRARIES PkgConfig::WPE)
     else ()
         set_property(TARGET WPE::libwpe PROPERTY
             INTERFACE_LINK_LIBRARIES "${WPE_LIBRARY}")


### PR DESCRIPTION
Versions of CMake prior to 3.11 do not support using `target_link_libraries()` to setup `INTERFACE_LINK_LIBRARIES`. Using `set_property()` directly works in all 3.x versions, including 3.11 and newer.

Fixes #75