### PR TITLE
Simplify Wayland version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ find_package(WPE REQUIRED)
 
 add_definitions(-DWPE_FDO_COMPILATION)
 
-if (NOT (WAYLAND_wayland-client_VERSION VERSION_LESS 1.10))
-    add_definitions(-DWAYLAND_1_10_OR_GREATER)
-endif ()
-
 configure_file(include/wpe-fdo/version.h.cmake "${CMAKE_BINARY_DIR}/wpe-fdo/version.h" @ONLY)
 
 set(WPEBACKEND_FDO_INCLUDE_DIRECTORIES

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -191,7 +191,7 @@ static const struct wl_surface_interface s_surfaceInterface = {
     [](struct wl_client*, struct wl_resource*, int32_t) { },
     // set_buffer_scale
     [](struct wl_client*, struct wl_resource*, int32_t) { },
-#ifdef WAYLAND_1_10_OR_GREATER
+#if (WAYLAND_VERSION_MAJOR > 1) || (WAYLAND_VERSION_MAJOR == 1 && WAYLAND_VERSION_MINOR >= 10)
     // damage_buffer
     [](struct wl_client*, struct wl_resource*, int32_t, int32_t, int32_t, int32_t) { },
 #endif


### PR DESCRIPTION
Instead of checking the Wayland version with CMake, and then adding a preprocessor macro, check the `WAYLAND_VERSION_*` values directly. Those
are defined by the Wayland headers.