### PR TITLE
Use GLib functions for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ find_package(Wayland REQUIRED client server egl)
 find_package(WaylandScanner REQUIRED)
 find_package(WPE REQUIRED)
 
-add_definitions(-DWPE_FDO_COMPILATION)
+add_definitions(-DWPE_FDO_COMPILATION -DG_LOG_DOMAIN=\"WPE-FDO\")
 
 configure_file(include/wpe-fdo/version.h.cmake "${CMAKE_BINARY_DIR}/wpe-fdo/version.h" @ONLY)
 

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<Connection> Connection::create(int fd, MessageReceiver* messageR
     GError* error = nullptr;
     auto* socket = g_socket_new_from_fd(fd, &error);
     if (!socket) {
-        fprintf(stderr, "WPE fdo failed to create socket for fd %d: %s", fd, error->message);
+        g_warning("Failed to create socket for fd %d: %s", fd, error->message);
         g_error_free(error);
 
         return nullptr;
@@ -73,7 +73,7 @@ void Connection::send(uint32_t messageId, uint32_t messageBody)
     uint32_t message[2] = { messageId, messageBody };
     gssize len = g_socket_send(m_socket, reinterpret_cast<gchar*>(message), messageSize, nullptr, &error);
     if (len == -1) {
-        fprintf(stderr, "WPE fdo failed to send message %u to socket: %s", messageId, error->message);
+        g_warning("Failed to send message %u to socket: %s", messageId, error->message);
         g_error_free(error);
     }
 }
@@ -87,7 +87,7 @@ gboolean Connection::s_socketCallback(GSocket* socket, GIOCondition condition, g
     uint32_t message[2];
     gssize len = g_socket_receive(socket, reinterpret_cast<gchar*>(message), messageSize, nullptr, &error);
     if (len == -1) {
-        fprintf(stderr, "WPE fdo failed to read message from socket: %s", error->message);
+        g_warning("Failed to read message from socket: %s", error->message);
         g_error_free(error);
         return FALSE;
     }

--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -191,7 +191,7 @@ void BaseTarget::initialize(struct wl_display* display)
 void BaseTarget::requestFrame()
 {
     if (m_wl.frameCallback)
-        std::abort();
+        g_error("BaseTarget::requestFrame(): A frame callback was already installed.");
 
     m_wl.frameCallback = wl_surface_frame(m_wl.surface);
     wl_callback_add_listener(m_wl.frameCallback, &s_callbackListener, this);

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -339,7 +339,7 @@ bool Instance::initialize(EGLDisplay eglDisplay)
         return true;
 
     if (m_eglDisplay != EGL_NO_DISPLAY) {
-        fprintf(stderr, "WPE fdo doesn't support multiple EGL displays\n");
+        g_warning("Multiple EGL displays are not supported.\n");
         return false;
     }
 
@@ -550,7 +550,7 @@ struct wl_client* Instance::registerViewBackend(uint32_t surfaceId, ExportableCl
 {
     auto it = m_viewBackendMap.find(surfaceId);
     if (it == m_viewBackendMap.end())
-        std::abort();
+        g_error("Instance::registerViewBackend(): " "Cannot find surface %" PRIu32 " in view backend map.", surfaceId);
 
     it->second->exportableClient = &exportableClient;
     return it->second->client;


### PR DESCRIPTION
This uses `g_warning(...)` instead of `fprintf(stderr, ...)`, and `g_error()`
instead of `std::abort()` so at least in case of fatal errors there will be a message that might be useful for developers before the process is terminated.

Additionally, sets `G_LOG_DOMAIN="WPE-FDO"` during compilation, so messages can be filtered i.e. using the `G_MESSAGES_DEBUG` environment variable.

Closes #67 and #68