### PR TITLE
DMABuf video plane display protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,13 @@ set(WPEBACKEND_FDO_PUBLIC_HEADERS
     include/wpe-fdo/fdo.h
 )
 
+set(WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS
+    include/wpe-fdo/extensions/video-plane-display-dmabuf.h
+)
+
 set(WPEBACKEND_FDO_GENERATED_SOURCES
     ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
+    ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-protocol.c
 )
 
 set(WPEBACKEND_FDO_SOURCES
@@ -95,6 +100,9 @@ set(WPEBACKEND_FDO_SOURCES
     src/ws.cpp
     src/ws-client.cpp
 
+    src/extensions/video-plane-display-dmabuf.cpp
+    src/extensions/video-plane-display-dmabuf-receiver.cpp
+
     src/linux-dmabuf/linux-dmabuf.cpp
     src/linux-dmabuf/linux-dmabuf-protocol.c
 )
@@ -108,6 +116,18 @@ add_custom_command(
     COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
     COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-client-protocol.h
     COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-server-protocol.h
+    VERBATIM
+)
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf)
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-protocol.c
+    OUTPUT ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-client-protocol.h
+    OUTPUT ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-server-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml
+    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-server-protocol.h
     VERBATIM
 )
 
@@ -136,6 +156,10 @@ install(
 install(
     FILES ${WPEBACKEND_FDO_PUBLIC_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wpe-fdo-${WPEBACKEND_FDO_API_VERSION}/wpe
+)
+install(
+    FILES ${WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wpe-fdo-${WPEBACKEND_FDO_API_VERSION}/wpe/extensions
 )
 
 configure_file(wpebackend-fdo.pc.in wpebackend-fdo-${WPEBACKEND_FDO_API_VERSION}.pc @ONLY)
@@ -166,6 +190,7 @@ if (BUILD_DOCS)
                 --extra-c-flags=-DWPE_FDO_COMPILATION
                 --c-sources
                     ${CMAKE_SOURCE_DIR}/include/wpe-fdo/*.h
+                    ${CMAKE_SOURCE_DIR}/include/wpe-fdo/extensions/*.h
                 --c-include-directories
                     ${CMAKE_SOURCE_DIR}/include
                     ${WPEBACKEND_FDO_INCLUDE_DIRECTORIES}

--- a/include/wpe-fdo/extensions/video-plane-display-dmabuf.h
+++ b/include/wpe-fdo/extensions/video-plane-display-dmabuf.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2019 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __video_plane_display_dmabuf_h__
+#define __video_plane_display_dmabuf_h__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * SECTION:video-plane-display-dmabuf
+ * @title: DMABuf Video plane display
+ * @short_description: Client-side video rendering support
+ *
+ * Usually WebKit takes care of video rendering by blending video frames in the
+ * RenderTree. In some situations (such as DRM-protected media content) the
+ * browser might need to handle video rendering itself, instead of letting
+ * WebKit do it. By doing this, the browser can guarantee that video frames
+ * wouldn't reach the user-space and would remain in the GPU as long as
+ * possible.
+ *
+ * To support this scenario, the browser (Cog for instance) should register a
+ * single #wpe_video_plane_display_dmabuf_receiver and implement the
+ * `handle_dmabuf` and `end_of_stream` callbacks. On the other end, WebKit
+ * should be compiled with the `-DUSE_WPE_VIDEO_PLANE_DISPLAY_DMABUF=ON` CMake
+ * option so that video frames are sent to the browser as DMABufs using the
+ * video-plane-display-dmabuf Wayland protocol. The browser will then be in
+ * charge of positioning and rendering the video frames. WebKit will simply
+ * render a transparent video rectangle placeholder in the RendeTree.
+ */
+
+struct wpe_renderer_backend_egl;
+struct wpe_video_plane_display_dmabuf_source;
+
+struct wpe_video_plane_display_dmabuf_source*
+wpe_video_plane_display_dmabuf_source_create(struct wpe_renderer_backend_egl*);
+
+void
+wpe_video_plane_display_dmabuf_source_destroy(struct wpe_video_plane_display_dmabuf_source*);
+
+typedef void (*wpe_video_plane_display_dmabuf_source_update_release_notify_t)(void *data);
+
+void
+wpe_video_plane_display_dmabuf_source_update(struct wpe_video_plane_display_dmabuf_source*, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride,
+    wpe_video_plane_display_dmabuf_source_update_release_notify_t notify, void* notify_data);
+
+void
+wpe_video_plane_display_dmabuf_source_end_of_stream(struct wpe_video_plane_display_dmabuf_source*);
+
+
+struct wpe_video_plane_display_dmabuf_export;
+
+struct wpe_video_plane_display_dmabuf_receiver {
+    void (*handle_dmabuf)(void* data, struct wpe_video_plane_display_dmabuf_export*, uint32_t id, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride);
+    void (*end_of_stream)(void* data, uint32_t id);
+    void (*_wpe_reserved0)(void);
+    void (*_wpe_reserved1)(void);
+    void (*_wpe_reserved2)(void);
+    void (*_wpe_reserved3)(void);
+};
+
+void
+wpe_video_plane_display_dmabuf_register_receiver(const struct wpe_video_plane_display_dmabuf_receiver*, void* data);
+
+void
+wpe_video_plane_display_dmabuf_export_release(struct wpe_video_plane_display_dmabuf_export*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __video_plane_display_dmabuf_h__

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2019 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "wpe-fdo/extensions/video-plane-display-dmabuf.h"
+
+#include "video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-client-protocol.h"
+#include "ws-client.h"
+#include <wpe/wpe-egl.h>
+#include <cstring>
+
+namespace Impl {
+
+class DmaBufThread {
+public:
+    static DmaBufThread& singleton();
+    static void initialize(struct wl_display*);
+
+    struct wl_event_queue* eventQueue() const { return m_wl.eventQueue; }
+
+private:
+    static DmaBufThread* s_thread;
+    static gpointer s_threadEntrypoint(gpointer);
+
+    explicit DmaBufThread(struct wl_display*);
+
+    struct ThreadSpawn {
+        GMutex mutex;
+        GCond cond;
+        DmaBufThread* thread;
+    };
+
+    struct {
+        struct wl_display* display;
+        struct wl_event_queue* eventQueue;
+    } m_wl;
+
+    struct {
+        GThread* thread;
+        GSource* wlSource;
+    } m_glib;
+};
+
+DmaBufThread* DmaBufThread::s_thread = nullptr;
+
+DmaBufThread& DmaBufThread::singleton()
+{
+    return *s_thread;
+}
+
+void DmaBufThread::initialize(struct wl_display* display)
+{
+    if (s_thread) {
+        if (s_thread->m_wl.display != display)
+            g_error("DmaBufThread: tried to reinitialize with a different wl_display object");
+    }
+
+    if (!s_thread)
+        s_thread = new DmaBufThread(display);
+}
+
+DmaBufThread::DmaBufThread(struct wl_display* display)
+{
+    m_wl.display = display;
+    m_wl.eventQueue = wl_display_create_queue(m_wl.display);
+
+    {
+        ThreadSpawn threadSpawn;
+        threadSpawn.thread = this;
+
+        g_mutex_init(&threadSpawn.mutex);
+        g_cond_init(&threadSpawn.cond);
+
+        g_mutex_lock(&threadSpawn.mutex);
+
+        m_glib.thread = g_thread_new("WPEBackend-fdo::video-plane-display-thread", s_threadEntrypoint, &threadSpawn);
+        g_cond_wait(&threadSpawn.cond, &threadSpawn.mutex);
+
+        g_mutex_unlock(&threadSpawn.mutex);
+
+        g_mutex_clear(&threadSpawn.mutex);
+        g_cond_clear(&threadSpawn.cond);
+    }
+}
+
+gpointer DmaBufThread::s_threadEntrypoint(gpointer data)
+{
+    auto& threadSpawn = *reinterpret_cast<ThreadSpawn*>(data);
+    g_mutex_lock(&threadSpawn.mutex);
+
+    auto& thread = *threadSpawn.thread;
+
+    GMainContext* context = g_main_context_new();
+    GMainLoop* loop = g_main_loop_new(context, FALSE);
+
+    g_main_context_push_thread_default(context);
+
+    thread.m_glib.wlSource = WS::ws_polling_source_new("WPEBackend-fdo::video-plane-display", thread.m_wl.display, thread.m_wl.eventQueue);
+    // The source is attached in the idle callback.
+
+    {
+        GSource* source = g_idle_source_new();
+        g_source_set_callback(source,
+            [](gpointer data) -> gboolean {
+                auto& threadSpawn = *reinterpret_cast<ThreadSpawn*>(data);
+
+                auto& thread = *threadSpawn.thread;
+                g_source_attach(thread.m_glib.wlSource, g_main_context_get_thread_default());
+
+                g_cond_signal(&threadSpawn.cond);
+                g_mutex_unlock(&threadSpawn.mutex);
+                return FALSE;
+            }, &threadSpawn, nullptr);
+        g_source_attach(source, context);
+        g_source_unref(source);
+    }
+
+    g_main_loop_run(loop);
+
+    g_main_context_pop_thread_default(context);
+    return nullptr;
+}
+
+class DmaBuf {
+public:
+    DmaBuf(WS::BaseBackend& backend)
+    {
+        struct wl_display* display = backend.display();
+        DmaBufThread::initialize(display);
+
+        struct wl_event_queue* eventQueue = wl_display_create_queue(display);
+
+        struct wl_registry* registry = wl_display_get_registry(display);
+        wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(registry), eventQueue);
+        wl_registry_add_listener(registry, &s_registryListener, this);
+        wl_display_roundtrip_queue(display, eventQueue);
+        wl_registry_destroy(registry);
+
+        wl_event_queue_destroy(eventQueue);
+    }
+
+    ~DmaBuf()
+    {
+        if (m_wl.videoPlaneDisplayDmaBuf)
+            wpe_video_plane_display_dmabuf_destroy(m_wl.videoPlaneDisplayDmaBuf);
+    }
+
+    void update(uint32_t id, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride,
+        wpe_video_plane_display_dmabuf_source_update_release_notify_t notify, void* notify_data)
+    {
+        auto* update = wpe_video_plane_display_dmabuf_create_update(m_wl.videoPlaneDisplayDmaBuf, id, fd, x, y, width, height, stride);
+
+        wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(update), DmaBufThread::singleton().eventQueue());
+        wpe_video_plane_display_dmabuf_update_add_listener(update, &s_videoPlaneDisplayUpdateListener, new ListenerData { notify, notify_data });
+    }
+
+    void end_of_stream(uint32_t id)
+    {
+        wpe_video_plane_display_dmabuf_end_of_stream(m_wl.videoPlaneDisplayDmaBuf, id);
+    }
+
+private:
+    static const struct wl_registry_listener s_registryListener;
+    static const struct wpe_video_plane_display_dmabuf_update_listener s_videoPlaneDisplayUpdateListener;
+
+    struct ListenerData {
+        wpe_video_plane_display_dmabuf_source_update_release_notify_t notify;
+        void* notify_data;
+    };
+
+    struct {
+        struct wpe_video_plane_display_dmabuf* videoPlaneDisplayDmaBuf { nullptr };
+    } m_wl;
+};
+
+const struct wl_registry_listener DmaBuf::s_registryListener = {
+    // global
+    [](void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t)
+    {
+        auto& impl = *reinterpret_cast<DmaBuf*>(data);
+        if (!std::strcmp(interface, "wpe_video_plane_display_dmabuf"))
+            impl.m_wl.videoPlaneDisplayDmaBuf = static_cast<struct wpe_video_plane_display_dmabuf*>(wl_registry_bind(registry, name, &wpe_video_plane_display_dmabuf_interface, 1));
+    },
+    // global_remove
+    [](void*, struct wl_registry*, uint32_t) { },
+};
+
+const struct wpe_video_plane_display_dmabuf_update_listener DmaBuf::s_videoPlaneDisplayUpdateListener = {
+    // release
+    [](void* data, struct wpe_video_plane_display_dmabuf_update* update)
+    {
+        auto* listenerData = static_cast<ListenerData*>(data);
+        if (listenerData->notify)
+            listenerData->notify(listenerData->notify_data);
+        delete listenerData;
+
+        wpe_video_plane_display_dmabuf_update_destroy(update);
+    },
+};
+
+}
+
+extern "C" {
+
+__attribute__((visibility("default")))
+struct wpe_video_plane_display_dmabuf_source*
+wpe_video_plane_display_dmabuf_source_create(struct wpe_renderer_backend_egl* backend)
+{
+    auto* base = reinterpret_cast<struct wpe_renderer_backend_egl_base*>(backend);
+    auto* impl = new Impl::DmaBuf(*static_cast<WS::BaseBackend*>(base->interface_data));
+    return reinterpret_cast<struct wpe_video_plane_display_dmabuf_source*>(impl);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_video_plane_display_dmabuf_source_destroy(struct wpe_video_plane_display_dmabuf_source* source)
+{
+    delete reinterpret_cast<Impl::DmaBuf*>(source);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_video_plane_display_dmabuf_source_update(struct wpe_video_plane_display_dmabuf_source* dmabuf_source, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride,
+    wpe_video_plane_display_dmabuf_source_update_release_notify_t notify, void* notify_data)
+{
+    auto& impl = *reinterpret_cast<Impl::DmaBuf*>(dmabuf_source);
+    uint32_t id = reinterpret_cast<uintptr_t>(dmabuf_source);
+    impl.update(id, fd, x, y, width, height, stride, notify, notify_data);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_video_plane_display_dmabuf_source_end_of_stream(struct wpe_video_plane_display_dmabuf_source* dmabuf_source)
+{
+    auto& impl = *reinterpret_cast<Impl::DmaBuf*>(dmabuf_source);
+    uint32_t id = reinterpret_cast<uintptr_t>(dmabuf_source);
+    impl.end_of_stream(id);
+}
+
+}

--- a/src/extensions/wpe-video-plane-display-dmabuf.xml
+++ b/src/extensions/wpe-video-plane-display-dmabuf.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wpe_video_plane_display_dmabuf">
+
+  <copyright>
+    Copyright © 2019 Igalia S.L.
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="wpe_video_plane_display_dmabuf" version="1">
+    <request name="create_update">
+      <arg name="id" type="new_id" interface="wpe_video_plane_display_dmabuf_update"/>
+      <arg name="video_id" type="uint" summary="video element unique identifier"/>
+      <arg name="fd" type="fd" summary="dmabuf fd"/>
+      <arg name="x" type="int" summary="video x position coordinate"/>
+      <arg name="y" type="int" summary="video y position coordinate"/>
+      <arg name="width" type="int" summary="width in pixels"/>
+      <arg name="height" type="int" summary="height in pixels"/>
+      <arg name="stride" type="uint" summary="stride in bytes"/>
+    </request>
+    <request name="end_of_stream">
+      <arg name="video_id" type="uint" summary="video element unique identifier"/>
+    </request>
+  </interface>
+
+  <interface name="wpe_video_plane_display_dmabuf_update" version="1">
+    <event name="release"/>
+    <request name="destroy" type="destructor"/>
+  </interface>
+
+</protocol>

--- a/src/ws-client.h
+++ b/src/ws-client.h
@@ -37,6 +37,7 @@ protected:
     BaseBackend(int hostFD);
     ~BaseBackend();
 
+public:
     struct wl_display* display() const { return m_wl.display; }
 
 private:
@@ -87,5 +88,7 @@ private:
         struct wl_callback* frameCallback { nullptr };
     } m_wl;
 };
+
+GSource* ws_polling_source_new(const char* name, struct wl_display*, struct wl_event_queue*);
 
 } // namespace WS

--- a/src/ws.h
+++ b/src/ws.h
@@ -34,6 +34,8 @@
 typedef void *EGLDisplay;
 typedef void *EGLImageKHR;
 
+struct wpe_video_plane_display_dmabuf_export;
+
 namespace WS {
 
 struct ExportableClient {
@@ -72,6 +74,13 @@ public:
     const struct linux_dmabuf_buffer* getDmaBufBuffer(struct wl_resource*) const;
     void foreachDmaBufModifier(std::function<void (int format, uint64_t modifier)>);
 
+    using VideoPlaneDisplayDmaBufCallback = std::function<void(struct wpe_video_plane_display_dmabuf_export*, uint32_t, int, int32_t, int32_t, int32_t, int32_t, uint32_t)>;
+    using VideoPlaneDisplayDmaBufEndOfStreamCallback = std::function<void(uint32_t)>;
+    void initializeVideoPlaneDisplayDmaBuf(VideoPlaneDisplayDmaBufCallback, VideoPlaneDisplayDmaBufEndOfStreamCallback);
+    void handleVideoPlaneDisplayDmaBuf(struct wpe_video_plane_display_dmabuf_export*, uint32_t id, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride);
+    void handleVideoPlaneDisplayDmaBufEndOfStream(uint32_t id);
+    void releaseVideoPlaneDisplayDmaBufExport(struct wpe_video_plane_display_dmabuf_export*);
+
 private:
     Instance();
 
@@ -85,6 +94,12 @@ private:
     std::unordered_map<uint32_t, Surface*> m_viewBackendMap;
 
     EGLDisplay m_eglDisplay;
+
+    struct {
+        struct wl_global* object { nullptr };
+        VideoPlaneDisplayDmaBufCallback updateCallback;
+        VideoPlaneDisplayDmaBufEndOfStreamCallback endOfStreamCallback;
+    } m_videoPlaneDisplayDmaBuf;
 };
 
 } // namespace WS


### PR DESCRIPTION
Introducing a new protocol enabling client-side video rendering. In WebKit
decoded video frames will be optionally exported to DMABuf fds and passed on
through the IPC wire using this protocol. On the other end, the browser (Cog for
instance) should receive all the informations needed so it can position and
render the video surfaces directly.

With contributions from Žan Doberšek <zdobersek@igalia.com>.