### PR TITLE
shm support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(WPEBACKEND_FDO_LIBRARIES
 set(WPEBACKEND_FDO_PUBLIC_HEADERS
     ${CMAKE_BINARY_DIR}/wpe-fdo/version.h
     include/wpe-fdo/exported-image-egl.h
+    include/wpe-fdo/exported-buffer-shm.h
     include/wpe-fdo/initialize-egl.h
     include/wpe-fdo/view-backend-exportable.h
     include/wpe-fdo/fdo-egl.h
@@ -83,6 +84,7 @@ set(WPEBACKEND_FDO_GENERATED_SOURCES
 set(WPEBACKEND_FDO_SOURCES
     ${WPEBACKEND_FDO_GENERATED_SOURCES}
 
+    src/exported-buffer-shm.cpp
     src/exported-image-egl.cpp
     src/fdo.cpp
     src/initialize-egl.cpp

--- a/include/wpe-fdo/exported-buffer-shm.h
+++ b/include/wpe-fdo/exported-buffer-shm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2020 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __WEBKIT_WEB_EXTENSION_H__
-#error "Headers <wpe/fdo-egl.h> and <wpe/webkit-web-extension.h> cannot be included together."
+#if !defined(__WPE_FDO_EGL_H_INSIDE__) && !defined(__WPE_FDO_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/fdo-egl.h> or <wpe/fdo.h> can be included directly."
 #endif
 
-#ifndef __wpe_fdo_egl_h__
-#define __wpe_fdo_egl_h__
+#ifndef __exported_buffer_shm_h__
+#define __exported_buffer_shm_h__
 
-#define __WPE_FDO_EGL_H_INSIDE__
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#include <wpe/exported-buffer-shm.h>
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
+#include <wpe/wpe.h>
 
-#undef __WPE_FDO_EGL_H_INSIDE__
+struct wpe_fdo_shm_exported_buffer;
 
-#endif /* __wpe_fdo_egl_h__ */
+struct wl_resource;
+struct wl_shm_buffer;
+
+struct wl_shm_buffer*
+wpe_fdo_shm_exported_buffer_get_shm_buffer(struct wpe_fdo_shm_exported_buffer*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __exported_buffer_shm_h__ */

--- a/include/wpe-fdo/fdo.h
+++ b/include/wpe-fdo/fdo.h
@@ -33,6 +33,7 @@
 #define __WPE_FDO_H_INSIDE__
 
 #include "version.h"
+#include <wpe/exported-buffer-shm.h>
 #include <wpe/view-backend-exportable.h>
 
 #undef __WPE_FDO_H_INSIDE__

--- a/include/wpe-fdo/view-backend-exportable-egl.h
+++ b/include/wpe-fdo/view-backend-exportable-egl.h
@@ -38,16 +38,16 @@ extern "C" {
 
 typedef void* EGLImageKHR;
 
-struct wpe_view_backend_exportable_fdo;
-
 struct wpe_fdo_egl_exported_image;
+struct wpe_fdo_shm_exported_buffer;
+struct wpe_view_backend_exportable_fdo;
 
 struct wpe_view_backend_exportable_fdo_egl_client {
     void (*export_egl_image)(void* data, EGLImageKHR image);
     void (*export_fdo_egl_image)(void* data, struct wpe_fdo_egl_exported_image* image);
+    void (*export_shm_buffer)(void* data, struct wpe_fdo_shm_exported_buffer* buffer);
     void (*_wpe_reserved0)(void);
     void (*_wpe_reserved1)(void);
-    void (*_wpe_reserved2)(void);
 };
 
 struct wpe_view_backend_exportable_fdo*
@@ -58,6 +58,9 @@ wpe_view_backend_exportable_fdo_egl_dispatch_release_image(struct wpe_view_backe
 
 void
 wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(struct wpe_view_backend_exportable_fdo*, struct wpe_fdo_egl_exported_image*);
+
+void
+wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer(struct wpe_view_backend_exportable_fdo*, struct wpe_fdo_shm_exported_buffer*);
 
 #ifdef __cplusplus
 }

--- a/include/wpe-fdo/view-backend-exportable.h
+++ b/include/wpe-fdo/view-backend-exportable.h
@@ -37,6 +37,8 @@ extern "C" {
 #include <wpe/wpe.h>
 
 struct wl_resource;
+
+struct wpe_fdo_shm_exported_buffer;
 struct wpe_view_backend_exportable_fdo;
 
 struct wpe_view_backend_exportable_fdo_dmabuf_resource {
@@ -54,9 +56,9 @@ struct wpe_view_backend_exportable_fdo_dmabuf_resource {
 struct wpe_view_backend_exportable_fdo_client {
     void (*export_buffer_resource)(void* data, struct wl_resource* buffer_resource);
     void (*export_dmabuf_resource)(void* data, struct wpe_view_backend_exportable_fdo_dmabuf_resource* dmabuf_resource);
+    void (*export_shm_buffer)(void* data, struct wpe_fdo_shm_exported_buffer*);
+    void (*_wpe_reserved0)(void);
     void (*_wpe_reserved1)(void);
-    void (*_wpe_reserved2)(void);
-    void (*_wpe_reserved3)(void);
 };
 
 struct wpe_view_backend_exportable_fdo*
@@ -73,6 +75,9 @@ wpe_view_backend_exportable_fdo_dispatch_frame_complete(struct wpe_view_backend_
 
 void
 wpe_view_backend_exportable_fdo_dispatch_release_buffer(struct wpe_view_backend_exportable_fdo*, struct wl_resource*);
+
+void
+wpe_view_backend_exportable_fdo_dispatch_release_shm_exported_buffer(struct wpe_view_backend_exportable_fdo*, struct wpe_fdo_shm_exported_buffer*);
 
 #ifdef __cplusplus
 }

--- a/src/exported-buffer-shm-private.h
+++ b/src/exported-buffer-shm-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2020 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __WEBKIT_WEB_EXTENSION_H__
-#error "Headers <wpe/fdo-egl.h> and <wpe/webkit-web-extension.h> cannot be included together."
-#endif
+#pragma once
 
-#ifndef __wpe_fdo_egl_h__
-#define __wpe_fdo_egl_h__
+struct wl_resource;
+struct wl_shm_buffer;
 
-#define __WPE_FDO_EGL_H_INSIDE__
-
-#include <wpe/exported-buffer-shm.h>
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
-
-#undef __WPE_FDO_EGL_H_INSIDE__
-
-#endif /* __wpe_fdo_egl_h__ */
+struct wpe_fdo_shm_exported_buffer {
+    struct wl_resource* resource;
+    struct wl_shm_buffer* shm_buffer;
+};

--- a/src/exported-buffer-shm.cpp
+++ b/src/exported-buffer-shm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2020 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __WEBKIT_WEB_EXTENSION_H__
-#error "Headers <wpe/fdo-egl.h> and <wpe/webkit-web-extension.h> cannot be included together."
-#endif
+#include "exported-buffer-shm-private.h"
 
-#ifndef __wpe_fdo_egl_h__
-#define __wpe_fdo_egl_h__
+extern "C" {
 
-#define __WPE_FDO_EGL_H_INSIDE__
+__attribute__((visibility("default")))
+struct wl_shm_buffer*
+wpe_fdo_shm_exported_buffer_get_shm_buffer(struct wpe_fdo_shm_exported_buffer* buffer)
+{
+    return buffer->shm_buffer;
+}
 
-#include <wpe/exported-buffer-shm.h>
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
-
-#undef __WPE_FDO_EGL_H_INSIDE__
-
-#endif /* __wpe_fdo_egl_h__ */
+}

--- a/src/linux-dmabuf/linux-dmabuf.cpp
+++ b/src/linux-dmabuf/linux-dmabuf.cpp
@@ -397,6 +397,18 @@ linux_dmabuf_setup(struct wl_display *wl_display)
                             NULL, bind_linux_dmabuf);
 }
 
+bool
+linux_dmabuf_buffer_implements_resource(struct wl_resource *resource)
+{
+    if (resource == NULL)
+        return 0;
+
+    if (wl_resource_instance_of(resource, &wl_buffer_interface,
+                                &linux_dmabuf_buffer_implementation))
+        return 1;
+    return 0;
+}
+
 void
 linux_dmabuf_buffer_destroy(struct linux_dmabuf_buffer *buffer)
 {

--- a/src/linux-dmabuf/linux-dmabuf.h
+++ b/src/linux-dmabuf/linux-dmabuf.h
@@ -38,5 +38,8 @@ struct linux_dmabuf_buffer {
 struct wl_global *
 linux_dmabuf_setup(struct wl_display *wl_display);
 
+bool
+linux_dmabuf_buffer_implements_resource(struct wl_resource*);
+
 void
 linux_dmabuf_buffer_destroy(struct linux_dmabuf_buffer *buffer);

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -103,6 +103,11 @@ public:
         client->export_egl_image(data, image);
     }
 
+    void exportBuffer(struct wl_resource*, struct wl_shm_buffer*) override
+    {
+        assert(!"noop");
+    }
+
     void releaseImage(EGLImageKHR image)
     {
         BufferResource* matchingResource = nullptr;
@@ -193,6 +198,11 @@ public:
         wl_resource_add_destroy_listener(dmabufBuffer->buffer_resource, &image->bufferDestroyListener);
 
         exportImage(image);
+    }
+
+    void exportBuffer(struct wl_resource*, struct wl_shm_buffer*) override
+    {
+        assert(!"noop");
     }
 
     void releaseImage(struct wpe_fdo_egl_exported_image* image)

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -105,6 +105,11 @@ public:
         client->export_dmabuf_resource(data, &dmabuf_resource);
     }
 
+    void exportBuffer(struct wl_resource*, struct wl_shm_buffer*) override
+    {
+        assert(!"noop");
+    }
+
     void releaseBuffer(struct wl_resource* buffer)
     {
         BufferResource* matchingResource = nullptr;

--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -93,6 +93,10 @@ void ViewBackend::exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buf
     m_clientBundle->exportBuffer(dmabuf_buffer);
 }
 
+void ViewBackend::exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*)
+{
+}
+
 void ViewBackend::dispatchFrameCallbacks()
 {
     FrameCallbackResource* resource;

--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -93,8 +93,9 @@ void ViewBackend::exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buf
     m_clientBundle->exportBuffer(dmabuf_buffer);
 }
 
-void ViewBackend::exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*)
+void ViewBackend::exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer)
 {
+    m_clientBundle->exportBuffer(bufferResource, shmBuffer);
 }
 
 void ViewBackend::dispatchFrameCallbacks()

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -63,6 +63,7 @@ public:
     void frameCallback(struct wl_resource* callbackResource) override;
     void exportBufferResource(struct wl_resource* bufferResource) override;
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
+    void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
     void dispatchFrameCallbacks();
     void releaseBuffer(struct wl_resource* buffer_resource);
 

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -46,6 +46,7 @@ public:
 
     virtual void exportBuffer(struct wl_resource *bufferResource) = 0;
     virtual void exportBuffer(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
+    virtual void exportBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) = 0;
 
     void* data;
     ViewBackend* viewBackend;

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -367,7 +367,7 @@ bool Instance::initialize(EGLDisplay eglDisplay)
         assert(s_eglDestroyImageKHR);
     }
 
-    if (s_eglBindWaylandDisplayWL) {
+    if (s_eglBindWaylandDisplayWL && s_eglQueryWaylandBufferWL) {
         if (!s_eglCreateImageKHR || !s_eglDestroyImageKHR)
             return false;
         if (!s_eglBindWaylandDisplayWL(eglDisplay, m_display))

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -348,7 +348,8 @@ bool Instance::initialize(EGLDisplay eglDisplay)
         return false;
     }
 
-    if (wl_display_init_shm(m_display))
+    // wl_display_init_shm() returns `0` on success.
+    if (wl_display_init_shm(m_display) != 0)
         return false;
 
     const char* extensions = eglQueryString(eglDisplay, EGL_EXTENSIONS);

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -135,6 +135,7 @@ struct Surface {
 
     struct wl_resource* bufferResource { nullptr };
     const struct linux_dmabuf_buffer* dmabufBuffer { nullptr };
+    struct wl_shm_buffer* shmBuffer { nullptr };
 };
 
 static const struct wl_surface_interface s_surfaceInterface = {
@@ -146,6 +147,7 @@ static const struct wl_surface_interface s_surfaceInterface = {
         auto& surface = *static_cast<Surface*>(wl_resource_get_user_data(surfaceResource));
 
         surface.dmabufBuffer = Instance::singleton().getDmaBufBuffer(bufferResource);
+        surface.shmBuffer = wl_shm_buffer_get(bufferResource);
 
         if (surface.bufferResource)
             wl_buffer_send_release(surface.bufferResource);
@@ -185,6 +187,8 @@ static const struct wl_surface_interface s_surfaceInterface = {
 
         if (surface.dmabufBuffer)
             surface.exportableClient->exportLinuxDmabuf(surface.dmabufBuffer);
+        else if (surface.shmBuffer)
+            surface.exportableClient->exportShmBuffer(bufferResource, surface.shmBuffer);
         else
             surface.exportableClient->exportBufferResource(bufferResource);
     },

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -348,6 +348,9 @@ bool Instance::initialize(EGLDisplay eglDisplay)
         return false;
     }
 
+    if (wl_display_init_shm(m_display))
+        return false;
+
     const char* extensions = eglQueryString(eglDisplay, EGL_EXTENSIONS);
     if (isEGLExtensionSupported(extensions, "EGL_WL_bind_wayland_display")) {
         s_eglBindWaylandDisplayWL = reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(eglGetProcAddress("eglBindWaylandDisplayWL"));
@@ -355,8 +358,6 @@ bool Instance::initialize(EGLDisplay eglDisplay)
         s_eglQueryWaylandBufferWL = reinterpret_cast<PFNEGLQUERYWAYLANDBUFFERWL>(eglGetProcAddress("eglQueryWaylandBufferWL"));
         assert(s_eglQueryWaylandBufferWL);
     }
-    if (!s_eglBindWaylandDisplayWL || !s_eglQueryWaylandBufferWL)
-        return false;
 
     if (isEGLExtensionSupported(extensions, "EGL_KHR_image_base")) {
         s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
@@ -364,11 +365,13 @@ bool Instance::initialize(EGLDisplay eglDisplay)
         s_eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
         assert(s_eglDestroyImageKHR);
     }
-    if (!s_eglCreateImageKHR || !s_eglDestroyImageKHR)
-        return false;
 
-    if (!s_eglBindWaylandDisplayWL(eglDisplay, m_display))
-        return false;
+    if (s_eglBindWaylandDisplayWL) {
+        if (!s_eglCreateImageKHR || !s_eglDestroyImageKHR)
+            return false;
+        if (!s_eglBindWaylandDisplayWL(eglDisplay, m_display))
+            return false;
+    }
 
     m_eglDisplay = eglDisplay;
 

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -506,7 +506,10 @@ void Instance::importDmaBufBuffer(struct linux_dmabuf_buffer* buffer)
 
 const struct linux_dmabuf_buffer* Instance::getDmaBufBuffer(struct wl_resource* bufferResource) const
 {
-    if (!m_linuxDmabuf)
+    if (!m_linuxDmabuf || !bufferResource)
+        return nullptr;
+
+    if (!linux_dmabuf_buffer_implements_resource(bufferResource))
         return nullptr;
 
     struct linux_dmabuf_buffer* buffer;

--- a/src/ws.h
+++ b/src/ws.h
@@ -40,6 +40,7 @@ struct ExportableClient {
     virtual void frameCallback(struct wl_resource*) = 0;
     virtual void exportBufferResource(struct wl_resource*) = 0;
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
+    virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
 };
 
 struct Surface;


### PR DESCRIPTION
Mainly:
* a small new API to chaperone the wl_shm_buffer object
* new export functions on the exportable interfaces
* wl_shm initialization
* optional EGL_wl_bind_wayland_display, in case the underlying GL library doesn't provide it when it's in software-rasterizer mode