### PR TITLE
ws: inlude eglmesaext.h

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -27,6 +27,7 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <EGL/eglmesaext.h>
 #include "linux-dmabuf/linux-dmabuf.h"
 #include "bridge/wpe-bridge-server-protocol.h"
 #include <cassert>


### PR DESCRIPTION
While building WebKit I came across with the build break of 1.4 release.

Digging the intertubes I found Archlinux reported the same issue and proposed this very same patch:
https://bugs.archlinux.org/task/64367

Also this header is already included in master, and this pull request is a cherry-pick of that commit.