### PR TITLE
Remove eglmesaext.h

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -27,7 +27,6 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <EGL/eglmesaext.h>
 #include "linux-dmabuf/linux-dmabuf.h"
 #include "bridge/wpe-bridge-server-protocol.h"
 #include "video-plane-display-dmabuf/wpe-video-plane-display-dmabuf-server-protocol.h"
@@ -40,6 +39,7 @@
 #ifndef EGL_WL_bind_wayland_display
 #define EGL_WAYLAND_BUFFER_WL 0x31D5
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYWAYLANDBUFFERWL) (EGLDisplay dpy, struct wl_resource *buffer, EGLint attribute, EGLint *value);
 #endif
 
 #ifndef EGL_EXT_image_dma_buf_import_modifiers


### PR DESCRIPTION
eglmesaext.h is not provided by all EGL implementations, but those
implementations typically provide the necessary definitions in eglext.h.
Add a configure time check to see if eglmesaext.h is present and include
it if so.