### PR TITLE
Install to the libwpe backends directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ set_target_properties(WPEBackend-fdo
 
 install(
     TARGETS WPEBackend-fdo
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${WPE_BACKENDS_DIR}
 )
 install(
     FILES ${WPEBACKEND_FDO_PUBLIC_HEADERS}

--- a/cmake/FindWPE.cmake
+++ b/cmake/FindWPE.cmake
@@ -4,8 +4,9 @@
 #  WPE_FOUND - system has WPE.
 #  WPE_INCLUDE_DIRS - the WPE include directories
 #  WPE_LIBRARIES - link these to use WPE.
+#  WPE_BACKENDS_DIR - location where to install WPE backends.
 #
-# Copyright (C) 2016 Igalia S.L.
+# Copyright (C) 2020, 2016 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,6 +31,7 @@
 
 find_package(PkgConfig)
 pkg_check_modules(WPE IMPORTED_TARGET wpe-1.0)
+pkg_get_variable(WPE_BACKENDS_DIR wpe-1.0 backendsdir)
 
 find_path(WPE_INCLUDE_DIR
     NAMES wpe/wpe.h
@@ -59,4 +61,5 @@ if (WPE_LIBRARY AND NOT TARGET WPE::libwpe)
 endif ()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(WPE REQUIRED_VARS WPE_LIBRARY WPE_INCLUDE_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(WPE
+    REQUIRED_VARS WPE_LIBRARY WPE_INCLUDE_DIR WPE_BACKENDS_DIR)

--- a/wpebackend-fdo.pc.in
+++ b/wpebackend-fdo.pc.in
@@ -8,4 +8,4 @@ Description: The WPEBackend-fdo library
 Version: @PROJECT_VERSION@
 Requires: wpe-1.0
 Cflags: -I${includedir}/wpe-fdo-@WPEBACKEND_FDO_API_VERSION@
-Libs: -L${libdir} -lWPEBackend-fdo-@WPEBACKEND_FDO_API_VERSION@
+Libs: -L@WPE_BACKENDS_DIR@ -lWPEBackend-fdo-@WPEBACKEND_FDO_API_VERSION@


### PR DESCRIPTION
Use pkg-config to obtain the value of the `backendsdir` variable to use the value as location for installing the backend. This also changes the pkg-config `.pc` file to have that list that directory in the `Libs` variable, so  pplications which need to link into `libWPEBackend-fdo-1.0` will still be able to find it.

----

This needs the changes from https://github.com/WebPlatformForEmbedded/libwpe/pull/64 and therefore the CI is expected to fail. See  https://github.com/WebPlatformForEmbedded/libwpe/issues/59 for more details.