### PR TITLE
Audio rendering protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,11 +89,13 @@ set(WPEBACKEND_FDO_UNSTABLE_PUBLIC_HEADERS
 
 set(WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS
     include/wpe/extensions/video-plane-display-dmabuf.h
+    include/wpe/extensions/audio.h
 )
 
 set(WPEBACKEND_FDO_GENERATED_SOURCES
     ${CMAKE_BINARY_DIR}/wpe-bridge-protocol.c
     ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-protocol.c
+    ${CMAKE_BINARY_DIR}/wpe-audio-protocol.c
 )
 
 set(WPEBACKEND_FDO_SOURCES
@@ -121,6 +123,9 @@ set(WPEBACKEND_FDO_SOURCES
 
     src/linux-dmabuf/linux-dmabuf.cpp
     src/linux-dmabuf/linux-dmabuf-protocol.c
+
+    src/extensions/audio.cpp
+    src/extensions/audio-receiver.cpp
 )
 
 add_custom_command(
@@ -142,6 +147,17 @@ add_custom_command(
     COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-protocol.c
     COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-client-protocol.h
     COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-video-plane-display-dmabuf.xml > ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-server-protocol.h
+    VERBATIM
+)
+
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-audio-protocol.c
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-audio-client-protocol.h
+    OUTPUT ${CMAKE_BINARY_DIR}/wpe-audio-server-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml
+    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml > ${CMAKE_BINARY_DIR}/wpe-audio-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml > ${CMAKE_BINARY_DIR}/wpe-audio-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml > ${CMAKE_BINARY_DIR}/wpe-audio-server-protocol.h
     VERBATIM
 )
 

--- a/include/wpe/extensions/audio.h
+++ b/include/wpe/extensions/audio.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __audio_h__
+#define __audio_h__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * SECTION:audio
+ * @title: Audio rendering
+ * @short_description: Client-side audio rendering support
+ *
+ * Usually WebKit takes care of audio rendering by connecting to the default
+ * audio system daemon such as PulseAudio or directly to ALSA. In some
+ * situations the UI process might want to handle PCM samples itself.
+ *
+ * To support this scenario, the UI process (created by GStreamer's wpesrc
+ * element for instance) should register a #wpe_audio_receiver, implement its
+ * callbacks and set the WebView audio-rendering-policy to
+ * WEBKIT_AUDIO_RENDERING_POLICY_EXTERNAL.
+ */
+
+
+struct wpe_renderer_backend_egl;
+struct wpe_audio_source;
+struct wpe_audio_packet_export;
+
+struct wpe_audio_source*
+wpe_audio_source_create(struct wpe_renderer_backend_egl*);
+
+void
+wpe_audio_source_destroy(struct wpe_audio_source*);
+
+void
+wpe_audio_source_start(struct wpe_audio_source* audio_source, uint32_t id, int32_t channels, const char* layout, int32_t sampleRate);
+
+void
+wpe_audio_source_packet(struct wpe_audio_source* audio_source, uint32_t id, int32_t fd, uint32_t frames);
+
+void
+wpe_audio_source_stop(struct wpe_audio_source* audio_source, uint32_t id);
+
+void
+wpe_audio_source_pause(struct wpe_audio_source* audio_source, uint32_t id);
+
+void
+wpe_audio_source_resume(struct wpe_audio_source* audio_source, uint32_t id);
+
+struct wpe_audio_receiver {
+  void (*handle_start)(void* data, uint32_t id, int32_t channels, const char* layout, int32_t sampleRate);
+  void (*handle_packet)(void* data, struct wpe_audio_packet_export*, uint32_t id, int32_t fd, uint32_t frames);
+  void (*handle_stop)(void* data, uint32_t id);
+  void (*handle_pause)(void* data, uint32_t id);
+  void (*handle_resume)(void* data, uint32_t id);
+};
+
+void wpe_audio_register_receiver(const struct wpe_audio_receiver*, void* data);
+
+void wpe_audio_packet_export_release(struct wpe_audio_packet_export*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __audio_h__

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,8 @@ sources = [
 	'src/ws-client.cpp',
 	'src/ws-egl.cpp',
 	'src/ws-shm.cpp',
+  'src/extensions/audio.cpp',
+  'src/extensions/audio-receiver.cpp',
 	'src/extensions/video-plane-display-dmabuf.cpp',
 	'src/extensions/video-plane-display-dmabuf-receiver.cpp',
 	'src/linux-dmabuf/linux-dmabuf.cpp',
@@ -79,6 +81,7 @@ api_headers = [
 ]
 
 extensions_api_headers = [
+  'include/wpe/extensions/audio.h',
 	'include/wpe/extensions/video-plane-display-dmabuf.h',
 ]
 
@@ -165,6 +168,26 @@ wpe_video_plane_display_dmabuf_proto_source = custom_target(
 	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
 )
 
+# Wayland extension: Audio rendering protocol.
+wpe_audio_client_proto_header = custom_target(
+	'audio-client-proto-header',
+	input: 'src/extensions/wpe-audio.xml',
+	output: '@BASENAME@-client-protocol.h',
+	command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_audio_server_proto_header = custom_target(
+	'audio-server-proto-header',
+	input: 'src/extensions/wpe-audio.xml',
+	output: '@BASENAME@-server-protocol.h',
+	command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_audio_proto_source = custom_target(
+	'audio-proto-source',
+	input: 'src/extensions/wpe-audio.xml',
+	output: '@BASENAME@-protocol.c',
+	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
+)
+
 cxx = meson.get_compiler('cpp')
 
 # Switch to the 'cpp_eh=none' default option when updating to Meson 0.51 or newer, see
@@ -215,6 +238,9 @@ generated_sources = [
 	wpe_bridge_proto_source,
 	wpe_bridge_client_proto_header,
 	wpe_bridge_server_proto_header,
+	wpe_audio_proto_source,
+	wpe_audio_client_proto_header,
+	wpe_audio_server_proto_header,
 	wpe_video_plane_display_dmabuf_proto_source,
 	wpe_video_plane_display_dmabuf_client_proto_header,
 	wpe_video_plane_display_dmabuf_server_proto_header,

--- a/meson.build
+++ b/meson.build
@@ -55,8 +55,8 @@ sources = [
 	'src/ws-client.cpp',
 	'src/ws-egl.cpp',
 	'src/ws-shm.cpp',
-  'src/extensions/audio.cpp',
-  'src/extensions/audio-receiver.cpp',
+	'src/extensions/audio.cpp',
+	'src/extensions/audio-receiver.cpp',
 	'src/extensions/video-plane-display-dmabuf.cpp',
 	'src/extensions/video-plane-display-dmabuf-receiver.cpp',
 	'src/linux-dmabuf/linux-dmabuf.cpp',
@@ -81,7 +81,7 @@ api_headers = [
 ]
 
 extensions_api_headers = [
-  'include/wpe/extensions/audio.h',
+	'include/wpe/extensions/audio.h',
 	'include/wpe/extensions/video-plane-display-dmabuf.h',
 ]
 

--- a/src/extensions/audio-receiver.cpp
+++ b/src/extensions/audio-receiver.cpp
@@ -55,7 +55,6 @@ static void dispatchReceiverStop(uint32_t id)
         s_registered_receiver.receiver->handle_stop(s_registered_receiver.data, id);
 }
 
-
 static void dispatchReceiverPause(uint32_t id)
 {
   if (s_registered_receiver.receiver)

--- a/src/extensions/audio-receiver.cpp
+++ b/src/extensions/audio-receiver.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "wpe/extensions/audio.h"
+
+#include "../ws.h"
+#include <unistd.h>
+
+static struct {
+    const struct wpe_audio_receiver* receiver;
+    void* data;
+} s_registered_receiver;
+
+static void dispatchReceiverStart(uint32_t id, int32_t channels, const char* layout, int32_t sampleRate)
+{
+    if (s_registered_receiver.receiver)
+        s_registered_receiver.receiver->handle_start(s_registered_receiver.data, id, channels, layout, sampleRate);
+}
+
+static void dispatchReceiverPacket(struct wpe_audio_packet_export* packet_export, uint32_t id, int32_t fd, uint32_t frames)
+{
+    if (s_registered_receiver.receiver)
+        s_registered_receiver.receiver->handle_packet(s_registered_receiver.data, packet_export, id, fd, frames);
+    else
+        wpe_audio_packet_export_release (packet_export);
+
+    close(fd);
+}
+
+static void dispatchReceiverStop(uint32_t id)
+{
+    if (s_registered_receiver.receiver)
+        s_registered_receiver.receiver->handle_stop(s_registered_receiver.data, id);
+}
+
+
+static void dispatchReceiverPause(uint32_t id)
+{
+  if (s_registered_receiver.receiver)
+      s_registered_receiver.receiver->handle_pause(s_registered_receiver.data, id);
+}
+
+
+static void dispatchReceiverResume(uint32_t id)
+{
+  if (s_registered_receiver.receiver)
+      s_registered_receiver.receiver->handle_resume(s_registered_receiver.data, id);
+}
+
+extern "C" {
+
+__attribute__((visibility("default")))
+void
+wpe_audio_register_receiver(const struct wpe_audio_receiver* receiver, void* data)
+{
+    s_registered_receiver.receiver = receiver;
+    s_registered_receiver.data = data;
+
+    WS::Instance::singleton().initializeAudio(&dispatchReceiverStart, &dispatchReceiverPacket, &dispatchReceiverStop, &dispatchReceiverPause, &dispatchReceiverResume);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_packet_export_release(struct wpe_audio_packet_export* packet_export)
+{
+    WS::Instance::singleton().releaseAudioPacketExport(packet_export);
+}
+
+}

--- a/src/extensions/audio.cpp
+++ b/src/extensions/audio.cpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "wpe/extensions/audio.h"
+
+#include "wpe-audio-client-protocol.h"
+#include "../ws-client.h"
+#include <wpe/wpe-egl.h>
+#include <cstring>
+
+namespace Impl {
+
+class AudioThread {
+public:
+    static AudioThread& singleton();
+    static void initialize(struct wl_display*);
+
+    struct wl_event_queue* eventQueue() const { return m_wl.eventQueue; }
+
+private:
+    static AudioThread* s_thread;
+    static gpointer s_threadEntrypoint(gpointer);
+
+    AudioThread(struct wl_display*);
+
+    struct ThreadSpawn {
+        GMutex mutex;
+        GCond cond;
+        AudioThread* thread;
+    };
+
+    struct {
+        struct wl_display* display;
+        struct wl_event_queue* eventQueue;
+    } m_wl;
+
+    struct {
+        GThread* thread;
+        GSource* wlSource;
+    } m_glib;
+};
+
+AudioThread* AudioThread::s_thread = nullptr;
+
+AudioThread& AudioThread::singleton()
+{
+    return *s_thread;
+}
+
+void AudioThread::initialize(struct wl_display* display)
+{
+    if (s_thread) {
+        if (s_thread->m_wl.display != display)
+            g_error("AudioThread: tried to reinitialize with a different wl_display object");
+    }
+
+    if (!s_thread)
+        s_thread = new AudioThread(display);
+}
+
+AudioThread::AudioThread(struct wl_display* display)
+{
+    m_wl.display = display;
+    m_wl.eventQueue = wl_display_create_queue(m_wl.display);
+
+    {
+        ThreadSpawn threadSpawn;
+        threadSpawn.thread = this;
+
+        g_mutex_init(&threadSpawn.mutex);
+        g_cond_init(&threadSpawn.cond);
+
+        g_mutex_lock(&threadSpawn.mutex);
+
+        m_glib.thread = g_thread_new("WPEBackend-fdo::audio-thread", s_threadEntrypoint, &threadSpawn);
+        g_cond_wait(&threadSpawn.cond, &threadSpawn.mutex);
+
+        g_mutex_unlock(&threadSpawn.mutex);
+
+        g_mutex_clear(&threadSpawn.mutex);
+        g_cond_clear(&threadSpawn.cond);
+    }
+}
+
+gpointer AudioThread::s_threadEntrypoint(gpointer data)
+{
+    auto& threadSpawn = *reinterpret_cast<ThreadSpawn*>(data);
+    g_mutex_lock(&threadSpawn.mutex);
+
+    auto& thread = *threadSpawn.thread;
+
+    GMainContext* context = g_main_context_new();
+    GMainLoop* loop = g_main_loop_new(context, FALSE);
+
+    g_main_context_push_thread_default(context);
+
+    thread.m_glib.wlSource = WS::ws_polling_source_new("WPEBackend-fdo::audio", thread.m_wl.display, thread.m_wl.eventQueue);
+    // The source is attached in the idle callback.
+
+    {
+        GSource* source = g_idle_source_new();
+        g_source_set_callback(source,
+            [](gpointer data) -> gboolean {
+                auto& threadSpawn = *reinterpret_cast<ThreadSpawn*>(data);
+
+                auto& thread = *threadSpawn.thread;
+                g_source_attach(thread.m_glib.wlSource, g_main_context_get_thread_default());
+
+                g_cond_signal(&threadSpawn.cond);
+                g_mutex_unlock(&threadSpawn.mutex);
+                return FALSE;
+            }, &threadSpawn, nullptr);
+        g_source_attach(source, context);
+        g_source_unref(source);
+    }
+
+    g_main_loop_run(loop);
+
+    g_main_loop_unref(loop);
+    g_main_context_pop_thread_default(context);
+    g_main_context_unref(context);
+    return nullptr;
+}
+
+class Audio {
+public:
+    Audio(WS::BaseBackend& backend)
+    {
+        struct wl_display* display = backend.display();
+        AudioThread::initialize(display);
+
+        struct wl_event_queue* eventQueue = wl_display_create_queue(display);
+
+        struct wl_registry* registry = wl_display_get_registry(display);
+        wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(registry), eventQueue);
+        wl_registry_add_listener(registry, &s_registryListener, this);
+        wl_display_roundtrip_queue(display, eventQueue);
+        wl_registry_destroy(registry);
+
+        wl_event_queue_destroy(eventQueue);
+    }
+
+    ~Audio()
+    {
+        if (m_wl.audio)
+            wpe_audio_destroy(m_wl.audio);
+    }
+
+    void start(uint32_t id, int32_t channels, const char* layout, int32_t sampleRate)
+    {
+        if (m_wl.audio)
+            wpe_audio_stream_started(m_wl.audio, id, channels, layout, sampleRate);
+    }
+
+    void packet(uint32_t id, int32_t fd, uint32_t frames)
+    {
+        if (!m_wl.audio)
+            return;
+
+        auto* update = wpe_audio_stream_packet(m_wl.audio, id, fd, frames);
+
+        wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(update), AudioThread::singleton().eventQueue());
+    }
+
+    void stop(uint32_t id)
+    {
+        wpe_audio_stream_stopped(m_wl.audio, id);
+    }
+
+    void pause(uint32_t id)
+    {
+        wpe_audio_stream_paused(m_wl.audio, id);
+    }
+
+    void resume(uint32_t id)
+    {
+        wpe_audio_stream_resumed(m_wl.audio, id);
+    }
+
+private:
+    static const struct wl_registry_listener s_registryListener;
+
+    struct {
+        struct wpe_audio* audio { nullptr };
+    } m_wl;
+};
+
+const struct wl_registry_listener Audio::s_registryListener = {
+    // global
+    [](void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t)
+    {
+        auto& impl = *reinterpret_cast<Audio*>(data);
+        if (!std::strcmp(interface, "wpe_audio"))
+            impl.m_wl.audio = static_cast<struct wpe_audio*>(wl_registry_bind(registry, name, &wpe_audio_interface, 1));
+    },
+    // global_remove
+    [](void*, struct wl_registry*, uint32_t) { },
+};
+
+}
+
+extern "C" {
+
+__attribute__((visibility("default")))
+struct wpe_audio_source*
+wpe_audio_source_create(struct wpe_renderer_backend_egl* backend)
+{
+    auto* base = reinterpret_cast<struct wpe_renderer_backend_egl_base*>(backend);
+    auto* impl = new Impl::Audio(*static_cast<WS::BaseBackend*>(base->interface_data));
+    return reinterpret_cast<struct wpe_audio_source*>(impl);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_source_destroy(struct wpe_audio_source* audio_source)
+{
+    delete reinterpret_cast<Impl::Audio*>(audio_source);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_source_start(struct wpe_audio_source* audio_source, uint32_t id, int32_t channels, const char* layout, int32_t sampleRate)
+{
+    auto& impl = *reinterpret_cast<Impl::Audio*>(audio_source);
+    impl.start(id, channels, layout, sampleRate);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_source_packet(struct wpe_audio_source* audio_source, uint32_t id, int32_t fd, uint32_t frames)
+{
+    auto& impl = *reinterpret_cast<Impl::Audio*>(audio_source);
+    impl.packet(id, fd, frames);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_source_stop(struct wpe_audio_source* audio_source, uint32_t id)
+{
+    auto& impl = *reinterpret_cast<Impl::Audio*>(audio_source);
+    impl.stop(id);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_source_pause(struct wpe_audio_source* audio_source, uint32_t id)
+{
+    auto& impl = *reinterpret_cast<Impl::Audio*>(audio_source);
+    impl.pause(id);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_audio_source_resume(struct wpe_audio_source* audio_source, uint32_t id)
+{
+    auto& impl = *reinterpret_cast<Impl::Audio*>(audio_source);
+    impl.resume(id);
+}
+
+}

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -138,7 +138,9 @@ gpointer DmaBufThread::s_threadEntrypoint(gpointer data)
 
     g_main_loop_run(loop);
 
+    g_main_loop_unref(loop);
     g_main_context_pop_thread_default(context);
+    g_main_context_unref(context);
     return nullptr;
 }
 

--- a/src/extensions/wpe-audio.xml
+++ b/src/extensions/wpe-audio.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wpe_audio">
+    <copyright>
+       Copyright © 2020 Igalia S.L.
+
+        Permission to use, copy, modify, distribute, and sell this
+        software and its documentation for any purpose is hereby granted
+        without fee, provided that the above copyright notice appear in
+        all copies and that both that copyright notice and this permission
+        notice appear in supporting documentation, and that the name of
+        the copyright holders not be used in advertising or publicity
+        pertaining to distribution of the software without specific,
+        written prior permission.  The copyright holders make no
+        representations about the suitability of this software for any
+        purpose.  It is provided "as is" without express or implied
+        warranty.
+
+        THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+        SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+        FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+        WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+        AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+        ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+        THIS SOFTWARE.
+    </copyright>
+
+    <interface name="wpe_audio" version="1">
+        <request name="stream_started">
+            <arg name="id" type="uint" summary="audio stream unique identifier"/>
+            <arg name="channels" type="int" summary="number of positional audio channels"/>
+            <arg name="layout" type="string" summary="audio format"/>
+            <arg name="samplerate" type="int" summary="sample rate"/>
+        </request>
+        <request name="stream_packet">
+            <arg name="id" type="new_id" interface="wpe_audio_packet_export"/>
+            <arg name="audio_stream_id" type="uint" summary="audio stream unique identifier"/>
+            <arg name="fd" type="fd" summary="PCM audio data"/>
+            <arg name="size" type="uint" summary="packet size in bytes"/>
+        </request>
+        <request name="stream_stopped">
+            <arg name="id" type="uint" summary="audio stream unique identifier"/>
+        </request>
+        <request name="stream_paused">
+            <arg name="id" type="uint" summary="audio stream unique identifier"/>
+        </request>
+        <request name="stream_resumed">
+            <arg name="id" type="uint" summary="audio stream unique identifier"/>
+        </request>
+    </interface>
+
+    <interface name="wpe_audio_packet_export" version="1">
+        <event name="release" />
+        <request name="destroy" type="destructor"/>
+    </interface>
+
+</protocol>

--- a/src/ws.h
+++ b/src/ws.h
@@ -33,6 +33,7 @@
 
 struct linux_dmabuf_buffer;
 struct wpe_video_plane_display_dmabuf_export;
+struct wpe_audio_packet_export;
 
 namespace WS {
 
@@ -101,6 +102,19 @@ public:
     void handleVideoPlaneDisplayDmaBufEndOfStream(uint32_t id);
     void releaseVideoPlaneDisplayDmaBufExport(struct wpe_video_plane_display_dmabuf_export*);
 
+    using AudioStartCallback = std::function<void(uint32_t, int32_t, const char*, int32_t)>;
+    using AudioPacketCallback = std::function<void(struct wpe_audio_packet_export*, uint32_t, int32_t, uint32_t)>;
+    using AudioStopCallback = std::function<void(uint32_t)>;
+    using AudioPauseCallback = std::function<void(uint32_t)>;
+    using AudioResumeCallback = std::function<void(uint32_t)>;
+    void initializeAudio(AudioStartCallback, AudioPacketCallback, AudioStopCallback, AudioPauseCallback, AudioResumeCallback);
+    void handleAudioStart(uint32_t id, int32_t channels, const char* layout, int32_t sampleRate);
+    void handleAudioPacket(struct wpe_audio_packet_export*, uint32_t id, int32_t fd, uint32_t frames);
+    void handleAudioStop(uint32_t id);
+    void handleAudioPause(uint32_t id);
+    void handleAudioResume(uint32_t id);
+    void releaseAudioPacketExport(struct wpe_audio_packet_export*);
+
 private:
     friend class Impl;
 
@@ -120,6 +134,15 @@ private:
         VideoPlaneDisplayDmaBufCallback updateCallback;
         VideoPlaneDisplayDmaBufEndOfStreamCallback endOfStreamCallback;
     } m_videoPlaneDisplayDmaBuf;
+
+    struct {
+        struct wl_global* object { nullptr };
+        AudioStartCallback startCallback;
+        AudioPacketCallback packetCallback;
+        AudioStopCallback stopCallback;
+        AudioPauseCallback pauseCallback;
+        AudioResumeCallback resumeCallback;
+    } m_audio;
 };
 
 template<typename T>


### PR DESCRIPTION
Usually WebKit takes care of audio rendering by connecting to the default
audio system daemon such as PulseAudio or directly to ALSA. In some
situations the UI process might want to handle PCM samples itself.

To support this scenario, the UI process (created by GStreamer's wpesrc
element for instance) should register a #wpe_audio_receiver, implement its
callbacks and set the WebView audio-rendering-policy to
WEBKIT_AUDIO_RENDERING_POLICY_EXTERNAL.