### PR TITLE
Remove wpe_renderer_host_exportable_fdo_initialize()

### DIFF
--- a/src/renderer-host.cpp
+++ b/src/renderer-host.cpp
@@ -43,14 +43,3 @@ struct wpe_renderer_host_interface fdo_renderer_host = {
         return WS::Instance::singleton().createClient();
     },
 };
-
-extern "C" {
-
-__attribute__((visibility("default")))
-void
-wpe_renderer_host_exportable_fdo_initialize(EGLDisplay eglDisplay)
-{
-    WS::Instance::singleton().initialize(eglDisplay);
-}
-
-}


### PR DESCRIPTION
The wpe_renderer_host_exportable_fdo_initialize() entrypoint is
an older version of wpe_fdo_initialize_for_egl_display() and should
have been removed already. It's not exposed in any header and was
thus not usable through API.