### PR TITLE
doc: Fix HotDoc warnings about missing headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,9 @@ if (BUILD_DOCS)
                     ${CMAKE_SOURCE_DIR}/include/wpe-fdo/extensions/*.h
                 --c-include-directories
                     ${CMAKE_SOURCE_DIR}/include
+                    ${CMAKE_BINARY_DIR}/wpe-fdo
                     ${WPEBACKEND_FDO_INCLUDE_DIRECTORIES}
+                    ${WPE_INCLUDE_DIR}
         )
     else ()
         message(FATAL_ERROR "Hotdoc C extension not found, can't build documentation.")

--- a/include/wpe-fdo/fdo-egl.h
+++ b/include/wpe-fdo/fdo-egl.h
@@ -32,10 +32,10 @@
 
 #define __WPE_FDO_EGL_H_INSIDE__
 
-#include <wpe/exported-buffer-shm.h>
-#include <wpe/exported-image-egl.h>
-#include <wpe/initialize-egl.h>
-#include <wpe/view-backend-exportable-egl.h>
+#include "exported-buffer-shm.h"
+#include "exported-image-egl.h"
+#include "initialize-egl.h"
+#include "view-backend-exportable-egl.h"
 
 #undef __WPE_FDO_EGL_H_INSIDE__
 

--- a/include/wpe-fdo/fdo.h
+++ b/include/wpe-fdo/fdo.h
@@ -33,8 +33,8 @@
 #define __WPE_FDO_H_INSIDE__
 
 #include "version.h"
-#include <wpe/exported-buffer-shm.h>
-#include <wpe/view-backend-exportable.h>
+#include "exported-buffer-shm.h"
+#include "view-backend-exportable.h"
 
 #undef __WPE_FDO_H_INSIDE__
 


### PR DESCRIPTION
Add the missing include directories to the HotDoc command and arrange headers to use local inclusion (with `""` instead of `<>`) to ensure that source tree files are picked first.