### PR TITLE
Provide SHM-only mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ set(WPEBACKEND_FDO_PUBLIC_HEADERS
     include/wpe-fdo/fdo-egl.h
     include/wpe-fdo/fdo.h
 )
+set(WPEBACKEND_FDO_UNSTABLE_PUBLIC_HEADERS
+    include/wpe-fdo/unstable/fdo-shm.h
+    include/wpe-fdo/unstable/initialize-shm.h
+)
 
 set(WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS
     include/wpe-fdo/extensions/video-plane-display-dmabuf.h
@@ -93,6 +97,7 @@ set(WPEBACKEND_FDO_SOURCES
     src/exported-image-egl.cpp
     src/fdo.cpp
     src/initialize-egl.cpp
+    src/initialize-shm.cpp
     src/ipc.cpp
     src/renderer-backend-egl.cpp
     src/renderer-host.cpp
@@ -102,6 +107,7 @@ set(WPEBACKEND_FDO_SOURCES
     src/ws.cpp
     src/ws-client.cpp
     src/ws-egl.cpp
+    src/ws-shm.cpp
 
     src/extensions/video-plane-display-dmabuf.cpp
     src/extensions/video-plane-display-dmabuf-receiver.cpp
@@ -161,6 +167,10 @@ install(
 install(
     FILES ${WPEBACKEND_FDO_PUBLIC_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wpe-fdo-${WPEBACKEND_FDO_API_VERSION}/wpe
+)
+install(
+    FILES ${WPEBACKEND_FDO_UNSTABLE_PUBLIC_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wpe-fdo-${WPEBACKEND_FDO_API_VERSION}/wpe/unstable
 )
 install(
     FILES ${WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS}

--- a/include/wpe-fdo/unstable/fdo-shm.h
+++ b/include/wpe-fdo/unstable/fdo-shm.h
@@ -1,0 +1,16 @@
+
+#ifdef __WEBKIT_WEB_EXTENSION_H__
+#error "Headers <wpe/unstable/fdo-shm.h> and <wpe/webkit-web-extension.h> cannot be included together."
+#endif
+
+#ifndef __wpe_fdo_shm_h__
+#define __wpe_fdo_shm_h__
+
+#define __WPE_FDO_SHM_H_INSIDE__
+
+#include <wpe/exported-buffer-shm.h>
+#include <wpe/unstable/initialize-shm.h>
+
+#undef __WPE_FDO_SHM_H_INSIDE__
+
+#endif /* __wpe_fdo_egl_h__ */

--- a/include/wpe-fdo/unstable/initialize-shm.h
+++ b/include/wpe-fdo/unstable/initialize-shm.h
@@ -23,29 +23,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !defined(__WPE_FDO_EGL_H_INSIDE__) && !defined(__WPE_FDO_SHM_H_INSIDE__) && !defined(__WPE_FDO_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
-#error "Only <wpe/fdo-egl.h>, <wpe/unstable/fdo-shm.h> or <wpe/fdo.h> can be included directly."
+#if !defined(__WPE_FDO_SHM_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/unstable/fdo-shm.h> can be included directly."
 #endif
 
-#ifndef __exported_buffer_shm_h__
-#define __exported_buffer_shm_h__
+#ifndef __initialize_shm_h__
+#define __initialize_shm_h__
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <wpe/wpe.h>
+#include <stdbool.h>
 
-struct wpe_fdo_shm_exported_buffer;
-
-struct wl_resource;
-struct wl_shm_buffer;
-
-struct wl_shm_buffer*
-wpe_fdo_shm_exported_buffer_get_shm_buffer(struct wpe_fdo_shm_exported_buffer*);
+bool
+wpe_fdo_initialize_shm(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __exported_buffer_shm_h__ */
+#endif /* __initialize_shm_h__ */

--- a/src/initialize-shm.cpp
+++ b/src/initialize-shm.cpp
@@ -23,29 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !defined(__WPE_FDO_EGL_H_INSIDE__) && !defined(__WPE_FDO_SHM_H_INSIDE__) && !defined(__WPE_FDO_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
-#error "Only <wpe/fdo-egl.h>, <wpe/unstable/fdo-shm.h> or <wpe/fdo.h> can be included directly."
-#endif
+#include "wpe-fdo/unstable/initialize-shm.h"
 
-#ifndef __exported_buffer_shm_h__
-#define __exported_buffer_shm_h__
+#include "ws-shm.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#include <wpe/wpe.h>
+__attribute__((visibility("default")))
+bool
+wpe_fdo_initialize_shm(void)
+{
+    WS::Instance::construct(std::unique_ptr<WS::ImplSHM>(new WS::ImplSHM));
 
-struct wpe_fdo_shm_exported_buffer;
-
-struct wl_resource;
-struct wl_shm_buffer;
-
-struct wl_shm_buffer*
-wpe_fdo_shm_exported_buffer_get_shm_buffer(struct wpe_fdo_shm_exported_buffer*);
-
-#ifdef __cplusplus
+    auto& instance = WS::Instance::singleton();
+    return static_cast<WS::ImplSHM&>(instance.impl()).initialize();
 }
-#endif
 
-#endif /* __exported_buffer_shm_h__ */
+}

--- a/src/ws-shm.cpp
+++ b/src/ws-shm.cpp
@@ -1,0 +1,41 @@
+#include "ws-shm.h"
+
+namespace WS {
+
+ImplSHM::ImplSHM() = default;
+ImplSHM::~ImplSHM() = default;
+
+void ImplSHM::surfaceAttach(Surface& surface, struct wl_resource* bufferResource)
+{
+    surface.shmBuffer = wl_shm_buffer_get(bufferResource);
+
+    if (surface.bufferResource)
+        wl_buffer_send_release(surface.bufferResource);
+    surface.bufferResource = bufferResource;
+}
+
+void ImplSHM::surfaceCommit(Surface& surface)
+{
+    if (!surface.exportableClient)
+        return;
+
+    struct wl_resource* bufferResource = surface.bufferResource;
+    surface.bufferResource = nullptr;
+
+    if (surface.shmBuffer)
+        surface.exportableClient->exportShmBuffer(bufferResource, surface.shmBuffer);
+    else
+        surface.exportableClient->exportBufferResource(bufferResource);
+}
+
+bool ImplSHM::initialize()
+{
+    // wl_display_init_shm() returns `0` on success.
+    if (wl_display_init_shm(display()) != 0)
+        return false;
+
+    m_initialized = true;
+    return true;
+}
+
+} // namespace WS

--- a/src/ws-shm.h
+++ b/src/ws-shm.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ws.h"
+
+namespace WS {
+
+class ImplSHM : public Instance::Impl {
+public:
+    ImplSHM();
+    virtual ~ImplSHM();
+
+    Type type() const override { return Instance::Impl::Type::SHM; }
+    bool initialized() const override { return m_initialized; }
+
+    void surfaceAttach(Surface&, struct wl_resource*) override;
+    void surfaceCommit(Surface&) override;
+
+    bool initialize();
+
+private:
+    bool m_initialized { false };
+};
+
+} // namespace WS

--- a/src/ws.h
+++ b/src/ws.h
@@ -61,6 +61,7 @@ public:
     public:
         enum class Type {
             EGL,
+            SHM,
         };
 
         Impl() = default;


### PR DESCRIPTION
Add possibility of only enabling wl_shm protocol on the Wayland
display connection, effectively forcing Mesa-based Wayland-EGL
platform implementations to perform software-based rasterization.
In this case, the `export_shm_buffer` callbacks on relevant
interfaces would be invoked with the relevant wl_shm buffer data.