### PR TITLE
Use libepoxy for EGL operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
       - cmake
       - libegl1-mesa-dev
+      - libepoxy-dev
       - libglib2.0-dev
       - libxkbcommon-dev
       - libwayland-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 sudo: false
 
 git:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ foreach (cflag -Wall)
     endif ()
 endforeach ()
 
-find_package(EGL REQUIRED)
+find_package(LibEpoxy REQUIRED)
 find_package(GLIB REQUIRED COMPONENTS gio gobject)
 find_package(Wayland REQUIRED client server egl)
 find_package(WaylandScanner REQUIRED)
@@ -60,7 +60,7 @@ set(WPEBACKEND_FDO_LIBRARIES
     ${GLIB_GIO_LIBRARIES}
     ${GLIB_GOBJECT_LIBRARIES}
     ${GLIB_LIBRARIES}
-    GL::egl
+    Epoxy::libepoxy
     Wayland::client
     Wayland::server
     Wayland::egl

--- a/cmake/FindLibEpoxy.cmake
+++ b/cmake/FindLibEpoxy.cmake
@@ -1,13 +1,11 @@
-# - Try to Find EGL
+# - Try to find libepoxy.
 # Once done, this will define
 #
-#  GL::egl - an imported library target.
-#  EGL_FOUND - a boolean variable.
-#  EGL_INCLUDE_DIR - directory containing the EGL/egl.h header.
-#  EGL_LIBRARY - path to the EGL library.
+#  EPOXY_FOUND - system has libepoxy
+#  EPOXY_INCLUDE_DIRS - the libepoxy include directories
+#  EPOXY_LIBRARIES - link these to use libepoxy.
 #
-# Copyright (C) 2019 Igalia S.L.
-# Copyright (C) 2012 Intel Corporation. All rights reserved.
+# Copyright (C) 2020 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,36 +28,35 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 find_package(PkgConfig)
-pkg_check_modules(EGL IMPORTED_TARGET egl)
+pkg_check_modules(EPOXY IMPORTED_TARGET epoxy)
 
-find_path(EGL_INCLUDE_DIR
-    NAMES EGL/egl.h
-    HINTS ${EGL_INCLUDEDIR} ${EGL_INCLUDE_DIRS}
+find_path(EPOXY_INCLUDE_DIR
+    NAMES epoxy/egl.h
+    HINTS ${EPOXY_INCLUDEDIR} ${EPOXY_INCLUDE_DIRS}
 )
-find_library(EGL_LIBRARY
-    NAMES egl EGL
-    HINTS ${EGL_LIBDIR} ${EGL_LIBRARY_DIRS}
+find_library(EPOXY_LIBRARY
+    NAMES epoxy
+    HINTS ${EPOXY_LIBDIR} ${EPOXY_LIBRARY_DIRS}
 )
-mark_as_advanced(EGL_INCLUDE_DIR EGL_LIBRARY)
+mark_as_advanced(EPOXY_INCLUDE_DIR EPOXY_LIBRARY)
 
 # If pkg-config has not found the module but find_path+find_library have
-# figured out where the header and library are, create the PkgConfig::EGL
+# figured out where the header and library are, create the PkgConfig::Epoxy
 # imported target anyway with the found paths.
 #
-if (EGL_LIBRARIES AND NOT TARGET GL::egl)
-    add_library(GL::egl INTERFACE IMPORTED)
-    if (TARGET PkgConfig::EGL)
-        set_property(TARGET GL::egl PROPERTY
-            INTERFACE_LINK_LIBRARIES PkgConfig::EGL)
+if (EPOXY_LIBRARIES AND NOT TARGET Epoxy::libepoxy)
+    add_library(Epoxy::libepoxy INTERFACE IMPORTED)
+    if (TARGET PkgConfig::EPOXY)
+        set_property(TARGET Epoxy::libepoxy PROPERTY
+            INTERFACE_LINK_LIBRARIES PkgConfig::EPOXY)
     else ()
-        set_property(TARGET GL::egl PROPERTY
-            INTERFACE_LINK_LIBRARIES ${EGL_LIBRARY})
-        set_property(TARGET GL::egl PROPERTY
-            INTERFACE_INCLUDE_DIRECTORIES ${EGL_INCLUDE_DIR})
+        set_property(TARGET Epoxy::libepoxy PROPERTY
+            INTERFACE_LINK_LIBRARIES ${EPOXY_LIBRARY})
+        set_property(TARGET Epoxy::libepoxy PROPERTY
+            INTERFACE_INCLUDE_DIRECTORIES ${EPOXY_INCLUDE_DIR})
     endif ()
 endif ()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(EGL REQUIRED_VARS EGL_LIBRARY EGL_INCLUDE_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(EPOXY REQUIRED_VARS EPOXY_LIBRARY EPOXY_INCLUDE_DIR)

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -28,8 +28,7 @@
 #include "view-backend-exportable-fdo-egl-private.h"
 #include "view-backend-exportable-private.h"
 #include "ws-egl.h"
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
+#include <epoxy/egl.h>
 #include <cassert>
 #include <list>
 #include <wpe-fdo/view-backend-exportable-egl.h>

--- a/src/ws-egl.cpp
+++ b/src/ws-egl.cpp
@@ -135,18 +135,23 @@ bool ImplEGL::initialize(EGLDisplay eglDisplay)
         return false;
     }
 
+    m_egl.WL_bind_wayland_display = epoxy_has_egl_extension(m_egl.display, "EGL_WL_bind_wayland_display");
+    m_egl.KHR_image_base = epoxy_has_egl_extension(m_egl.display, "EGL_KHR_image_base");
+    m_egl.EXT_image_dma_buf_import = epoxy_has_egl_extension(m_egl.display, "EGL_EXT_image_dma_buf_import");
+    m_egl.EXT_image_dma_buf_import_modifiers = epoxy_has_egl_extension(m_egl.display, "EGL_EXT_image_dma_buf_import_modifiers");
+
     // wl_display_init_shm() returns `0` on success.
     if (wl_display_init_shm(display()) != 0)
         return false;
 
-    if (epoxy_has_egl_extension(eglDisplay, "EGL_WL_bind_wayland_display")) {
+    if (m_egl.WL_bind_wayland_display) {
         s_eglBindWaylandDisplayWL = reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(eglGetProcAddress("eglBindWaylandDisplayWL"));
         assert(s_eglBindWaylandDisplayWL);
         s_eglQueryWaylandBufferWL = reinterpret_cast<PFNEGLQUERYWAYLANDBUFFERWL>(eglGetProcAddress("eglQueryWaylandBufferWL"));
         assert(s_eglQueryWaylandBufferWL);
     }
 
-    if (epoxy_has_egl_extension(eglDisplay, "EGL_KHR_image_base")) {
+    if (m_egl.KHR_image_base) {
         s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
         assert(s_eglCreateImageKHR);
         s_eglDestroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
@@ -164,8 +169,7 @@ bool ImplEGL::initialize(EGLDisplay eglDisplay)
     m_egl.display = eglDisplay;
 
     /* Initialize Linux dmabuf subsystem. */
-    if (epoxy_has_egl_extension(eglDisplay, "EGL_EXT_image_dma_buf_import")
-        && epoxy_has_egl_extension(eglDisplay, "EGL_EXT_image_dma_buf_import_modifiers")) {
+    if (m_egl.EXT_image_dma_buf_import && m_egl.EXT_image_dma_buf_import_modifiers) {
         s_eglQueryDmaBufFormatsEXT = reinterpret_cast<PFNEGLQUERYDMABUFFORMATSEXTPROC>(eglGetProcAddress("eglQueryDmaBufFormatsEXT"));
         assert(s_eglQueryDmaBufFormatsEXT);
         s_eglQueryDmaBufModifiersEXT = reinterpret_cast<PFNEGLQUERYDMABUFMODIFIERSEXTPROC>(eglGetProcAddress("eglQueryDmaBufModifiersEXT"));

--- a/src/ws-egl.h
+++ b/src/ws-egl.h
@@ -60,6 +60,11 @@ private:
 
     struct {
         EGLDisplay display;
+
+        bool WL_bind_wayland_display { false };
+        bool KHR_image_base { false };
+        bool EXT_image_dma_buf_import { false };
+        bool EXT_image_dma_buf_import_modifiers { false };
     } m_egl;
 
     struct {

--- a/src/ws-egl.h
+++ b/src/ws-egl.h
@@ -57,7 +57,10 @@ public:
 
 private:
     bool m_initialized { false };
-    EGLDisplay m_eglDisplay;
+
+    struct {
+        EGLDisplay display;
+    } m_egl;
 
     struct {
         struct wl_global* global { nullptr };


### PR DESCRIPTION
Instead of relying on EGL headers and library provided at compile-time,
use libepoxy to push that necessity to runtime.

The CMake integration follows the new 'imported' model. Instead of
manually parsing the EGL extension list to detect present extensions,
we can rely on the epoxy_has_egl_extension() function.