### PR TITLE
Provide EGLStream mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,11 @@ set(WPEBACKEND_FDO_PUBLIC_HEADERS
     include/wpe/fdo.h
 )
 set(WPEBACKEND_FDO_UNSTABLE_PUBLIC_HEADERS
+    include/wpe/unstable/fdo-eglstream.h
     include/wpe/unstable/fdo-shm.h
+    include/wpe/unstable/initialize-eglstream.h
     include/wpe/unstable/initialize-shm.h
+    include/wpe/unstable/view-backend-exportable-eglstream.h
 )
 
 set(WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS
@@ -93,6 +96,7 @@ set(WPEBACKEND_FDO_EXTENSIONS_PUBLIC_HEADERS
 )
 
 set(WPEBACKEND_FDO_GENERATED_SOURCES
+    ${CMAKE_BINARY_DIR}/wayland-eglstream-controller-protocol.c
     ${CMAKE_BINARY_DIR}/wpe-bridge-protocol.c
     ${CMAKE_BINARY_DIR}/wpe-video-plane-display-dmabuf-protocol.c
     ${CMAKE_BINARY_DIR}/wpe-audio-protocol.c
@@ -105,6 +109,7 @@ set(WPEBACKEND_FDO_SOURCES
     src/exported-image-egl.cpp
     src/fdo.cpp
     src/initialize-egl.cpp
+    src/initialize-eglstream.cpp
     src/initialize-shm.cpp
     src/ipc.cpp
     src/renderer-backend-egl.cpp
@@ -112,10 +117,12 @@ set(WPEBACKEND_FDO_SOURCES
     src/version.c
     src/view-backend-exportable-fdo.cpp
     src/view-backend-exportable-fdo-egl.cpp
+    src/view-backend-exportable-fdo-eglstream.cpp
     src/view-backend-exportable-private.cpp
     src/ws.cpp
     src/ws-client.cpp
     src/ws-egl.cpp
+    src/ws-eglstream.cpp
     src/ws-shm.cpp
 
     src/extensions/video-plane-display-dmabuf.cpp
@@ -158,6 +165,16 @@ add_custom_command(
     COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml > ${CMAKE_BINARY_DIR}/wpe-audio-protocol.c
     COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml > ${CMAKE_BINARY_DIR}/wpe-audio-client-protocol.h
     COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/extensions/wpe-audio.xml > ${CMAKE_BINARY_DIR}/wpe-audio-server-protocol.h
+    VERBATIM
+)
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/wayland-eglstream)
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/wayland-eglstream-controller-protocol.c
+    OUTPUT ${CMAKE_BINARY_DIR}/wayland-eglstream-controller-server-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/wayland-eglstream/wayland-eglstream-controller.xml
+    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/wayland-eglstream/wayland-eglstream-controller.xml > ${CMAKE_BINARY_DIR}/wayland-eglstream-controller-protocol.c
+    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/wayland-eglstream/wayland-eglstream-controller.xml > ${CMAKE_BINARY_DIR}/wayland-eglstream-controller-server-protocol.h
     VERBATIM
 )
 

--- a/include/wpe/unstable/fdo-eglstream.h
+++ b/include/wpe/unstable/fdo-eglstream.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __WEBKIT_WEB_EXTENSION_H__
+#error "Headers <wpe/unstable/fdo-eglstream.h> and <wpe/webkit-web-extension.h> cannot be included together."
+#endif
+
+#ifndef __wpe_fdo_eglstream_h__
+#define __wpe_fdo_eglstream_h__
+
+#define __WPE_FDO_EGLSTREAM_H_INSIDE__
+
+#include <wpe/unstable/initialize-eglstream.h>
+#include <wpe/unstable/view-backend-exportable-eglstream.h>
+
+#undef __WPE_FDO_EGLSTREAM_H_INSIDE__
+
+#endif /* __wpe_fdo_eglstream_h__ */

--- a/include/wpe/unstable/initialize-eglstream.h
+++ b/include/wpe/unstable/initialize-eglstream.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !defined(__WPE_FDO_EGLSTREAM_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/unstable/fdo-eglstream.h> can be included directly."
+#endif
+
+#ifndef __initialize_eglstream_h__
+#define __initialize_eglstream_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+typedef void *EGLDisplay;
+
+bool
+wpe_fdo_initialize_eglstream(EGLDisplay);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __initialize_eglstream_h__ */

--- a/include/wpe/unstable/view-backend-exportable-eglstream.h
+++ b/include/wpe/unstable/view-backend-exportable-eglstream.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !defined(__WPE_FDO_EGLSTREAM_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/unstable/fdo-eglstream.h> can be included directly."
+#endif
+
+#ifndef __view_backend_exportable_eglstream_h__
+#define __view_backend_exportable_eglstream_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wpe/wpe.h>
+
+struct wl_resource;
+struct wpe_view_backend_exportable_fdo;
+
+struct wpe_view_backend_exportable_fdo_eglstream_client {
+    void (*export_eglstream_producer_resource)(void* data, struct wl_resource* buffer_resource);
+    void (*notify_eglstream_frame)(void* data);
+    void (*_wpe_reserved0)(void);
+    void (*_wpe_reserved1)(void);
+    void (*_wpe_reserved2)(void);
+};
+
+struct wpe_view_backend_exportable_fdo*
+wpe_view_backend_exportable_fdo_eglstream_create(const struct wpe_view_backend_exportable_fdo_eglstream_client*, void*, uint32_t width, uint32_t height);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __view_backend_exportable_egl_h___ */

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ sources = [
 	'src/exported-image-egl.cpp',
 	'src/fdo.cpp',
 	'src/initialize-egl.cpp',
+	'src/initialize-eglstream.cpp',
 	'src/initialize-shm.cpp',
 	'src/ipc.cpp',
 	'src/renderer-backend-egl.cpp',
@@ -50,10 +51,12 @@ sources = [
 	'src/version.c',
 	'src/view-backend-exportable-fdo.cpp',
 	'src/view-backend-exportable-fdo-egl.cpp',
+	'src/view-backend-exportable-fdo-eglstream.cpp',
 	'src/view-backend-exportable-private.cpp',
 	'src/ws.cpp',
 	'src/ws-client.cpp',
 	'src/ws-egl.cpp',
+	'src/ws-eglstream.cpp',
 	'src/ws-shm.cpp',
 	'src/extensions/audio.cpp',
 	'src/extensions/audio-receiver.cpp',
@@ -86,8 +89,11 @@ extensions_api_headers = [
 ]
 
 unstable_api_headers = [
+	'include/wpe/unstable/fdo-eglstream.h',
 	'include/wpe/unstable/fdo-shm.h',
 	'include/wpe/unstable/initialize-shm.h',
+	'include/wpe/unstable/initialize-eglstream.h',
+	'include/wpe/unstable/view-backend-exportable-eglstream.h',
 ]
 
 add_project_arguments(
@@ -188,6 +194,21 @@ wpe_audio_proto_source = custom_target(
 	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
 )
 
+# Wayland extension: EGLStream controller
+wayland_eglstream_controller_server_proto_header = custom_target(
+	'wayland-eglstream-controller-server-proto-header',
+	input: 'src/wayland-eglstream/wayland-eglstream-controller.xml',
+	output: '@BASENAME@-server-protocol.h',
+	command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+
+wayland_eglstream_controller_proto_source = custom_target(
+	'wayland-eglstream-controller-proto-source',
+	input: 'src/wayland-eglstream/wayland-eglstream-controller.xml',
+	output: '@BASENAME@-protocol.c',
+	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
+)
+
 cxx = meson.get_compiler('cpp')
 
 # Switch to the 'cpp_eh=none' default option when updating to Meson 0.51 or newer, see
@@ -244,6 +265,8 @@ generated_sources = [
 	wpe_video_plane_display_dmabuf_proto_source,
 	wpe_video_plane_display_dmabuf_client_proto_header,
 	wpe_video_plane_display_dmabuf_server_proto_header,
+	wayland_eglstream_controller_proto_source,
+	wayland_eglstream_controller_server_proto_header,
 ]
 
 lib = shared_library(meson.project_name() + '-' + api_version,

--- a/src/initialize-eglstream.cpp
+++ b/src/initialize-eglstream.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "wpe/unstable/initialize-eglstream.h"
+
+#include "ws-eglstream.h"
+
+extern "C" {
+
+__attribute__((visibility("default")))
+bool
+wpe_fdo_initialize_eglstream(EGLDisplay display)
+{
+    WS::Instance::construct(std::unique_ptr<WS::ImplEGLStream>(new WS::ImplEGLStream));
+
+    auto& instance = WS::Instance::singleton();
+    return static_cast<WS::ImplEGLStream&>(instance.impl()).initialize(display);
+}
+
+}

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -113,6 +113,11 @@ public:
         client->export_shm_buffer(data, buffer);
     }
 
+    void exportEGLStreamProducer(struct wl_resource* bufferResource) override
+    {
+        assert(!"should not be reached");
+    }
+
     void releaseImage(EGLImageKHR image)
     {
         BufferResource* matchingResource = nullptr;
@@ -211,6 +216,11 @@ public:
         buffer->resource = bufferResource;
         buffer->shm_buffer = shmBuffer;
         client->export_shm_buffer(data, buffer);
+    }
+
+    void exportEGLStreamProducer(struct wl_resource* bufferResource) override
+    {
+        assert(!"should not be reached");
     }
 
     void releaseImage(struct wpe_fdo_egl_exported_image* image)

--- a/src/view-backend-exportable-fdo-eglstream.cpp
+++ b/src/view-backend-exportable-fdo-eglstream.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "view-backend-exportable-private.h"
+#include <cassert>
+#include <wpe/unstable/view-backend-exportable-eglstream.h>
+
+namespace {
+
+class ClientBundleEGLStream final : public ClientBundle {
+public:
+    ClientBundleEGLStream(const struct wpe_view_backend_exportable_fdo_eglstream_client* client,
+        void* data, ViewBackend* viewBackend, uint32_t width, uint32_t height)
+        : ClientBundle(data, viewBackend, width, height)
+        , client(client)
+    {
+    }
+
+    virtual ~ClientBundleEGLStream() = default;
+
+    void exportBuffer(struct wl_resource *buffer) override
+    {
+        // The Wayland integration with EGLStream in NVIDIA drivers is a bit strange.
+        // For each swap call, the client will first attach the frame's output buffer
+        // and commit that state before doing a round-trip through the EGLStream
+        // consumer, after which another commit on the surface is done. We wait for
+        // this second commit, detecting it based on the buffer resource being null
+        // here (since the first received commit cleared out the buffer resource in
+        // ImplEGLStream::surfaceCommit().
+        if (!!buffer)
+            return;
+
+        client->notify_eglstream_frame(data);
+    }
+
+    void exportBuffer(const struct linux_dmabuf_buffer *dmabuf_buffer) override
+    {
+        assert(!"should not be reached");
+    }
+
+    void exportBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override
+    {
+        assert(!"should not be reached");
+    }
+
+    void exportEGLStreamProducer(struct wl_resource* bufferResource) override
+    {
+        client->export_eglstream_producer_resource(data, bufferResource);
+    }
+
+    const struct wpe_view_backend_exportable_fdo_eglstream_client* client;
+};
+
+} // namespace
+
+extern "C" {
+
+__attribute__((visibility("default")))
+struct wpe_view_backend_exportable_fdo*
+wpe_view_backend_exportable_fdo_eglstream_create(const struct wpe_view_backend_exportable_fdo_eglstream_client* client, void* data, uint32_t width, uint32_t height)
+{
+    auto* clientBundle = new ClientBundleEGLStream(client, data, nullptr, width, height);
+    struct wpe_view_backend* backend = wpe_view_backend_create_with_backend_interface(&view_backend_exportable_fdo_interface, clientBundle);
+
+    auto* exportable = new struct wpe_view_backend_exportable_fdo;
+    exportable->clientBundle = clientBundle;
+    exportable->backend = backend;
+
+    return exportable;
+}
+
+}

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -115,6 +115,11 @@ public:
         client->export_shm_buffer(data, buffer);
     }
 
+    void exportEGLStreamProducer(struct wl_resource* bufferResource) override
+    {
+        assert(!"should not be reached");
+    }
+
     void releaseBuffer(struct wl_resource* buffer)
     {
         BufferResource* matchingResource = nullptr;

--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -98,6 +98,11 @@ void ViewBackend::exportShmBuffer(struct wl_resource* bufferResource, struct wl_
     m_clientBundle->exportBuffer(bufferResource, shmBuffer);
 }
 
+void ViewBackend::exportEGLStreamProducer(struct wl_resource* bufferResource)
+{
+    m_clientBundle->exportEGLStreamProducer(bufferResource);
+}
+
 void ViewBackend::dispatchFrameCallbacks()
 {
     FrameCallbackResource* resource;

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -48,6 +48,7 @@ public:
     virtual void exportBuffer(struct wl_resource *bufferResource) = 0;
     virtual void exportBuffer(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) = 0;
+    virtual void exportEGLStreamProducer(struct wl_resource *bufferResource) = 0;
 
     void* data;
     ViewBackend* viewBackend;
@@ -66,6 +67,7 @@ public:
     void exportBufferResource(struct wl_resource* bufferResource) override;
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
     void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
+    void exportEGLStreamProducer(struct wl_resource*) override;
     void dispatchFrameCallbacks();
     void releaseBuffer(struct wl_resource* buffer_resource);
 

--- a/src/wayland-eglstream/wayland-eglstream-controller.xml
+++ b/src/wayland-eglstream/wayland-eglstream-controller.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wl_eglstream_controller">
+  <copyright>
+    Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+  <interface name="wl_eglstream_controller" version="2">
+    <!-- Present mode types. This enum defines what the present mode given
+         to a attach_eglstream_consumer_attribs request represents -->
+    <enum name="present_mode">
+      <description summary="Stream present mode">
+          - dont_care: Using this enum will tell the server to make its own
+                       decisions regarding present mode.
+
+          - fifo:      Tells the server to use a fifo present mode. The decision to
+                       use fifo synchronous is left up to the server.
+
+          - mailbox:   Tells the server to use a mailbox present mode.
+      </description>
+      <entry name="dont_care" value="0" summary="Let the Server decide present mode"/>
+      <entry name="fifo" value="1" summary="Use a fifo present mode"/>
+      <entry name="mailbox" value="2" summary="Use a mailbox mode"/>
+    </enum>
+
+    <enum name="attrib">
+      <description summary="Stream consumer attachment attributes">
+          - present_mode: Must be one of wl_eglstream_controller_present_mode. Tells the
+                          server the desired present mode that should be used.
+
+          - fifo_length:  Only valid when the present_mode attrib is provided and its
+                          value is specified as fifo. Tells the server the desired fifo
+                          length to be used when the desired present_mode is fifo.
+      </description>
+      <entry name="present_mode" value="0" summary="Tells the server the desired present mode"/>
+      <entry name="fifo_length" value="1" summary="Tells the server the desired fifo length when the desired presenation_mode is fifo."/>
+    </enum>
+
+    <request name="attach_eglstream_consumer" since="1">
+      <description summary="Create server stream and attach consumer">
+        Creates the corresponding server side EGLStream from the given wl_buffer
+        and attaches a consumer to it.
+      </description>
+      <arg name="wl_surface" type="object" interface="wl_surface"
+        summary="wl_surface corresponds to the client surface associated with
+        newly created eglstream"/>
+      <arg name="wl_resource" type="object" interface="wl_buffer"
+        summary="wl_resource corresponding to an EGLStream"/>
+    </request>
+
+    <request name="attach_eglstream_consumer_attribs" since="2">
+      <description summary="Create server stream and attach consumer using attributes">
+        Creates the corresponding server side EGLStream from the given wl_buffer
+        and attaches a consumer to it using the given attributes.
+      </description>
+      <arg name="wl_surface" type="object" interface="wl_surface"
+        summary="wl_surface corresponds to the client surface associated with
+        newly created eglstream"/>
+      <arg name="wl_resource" type="object" interface="wl_buffer"
+        summary="wl_resource corresponding to an EGLStream"/>
+      <arg name="attribs" type="array"
+        summary="Stream consumer attachment attribs">
+        <description summary="List of attributes with consumer attachment data">
+          It contains key-value pairs compatible with intptr_t type. A key must
+          be one of wl_eglstream_controller_attrib enumeration values. What a value
+          represents is attribute-specific.
+        </description>
+      </arg>
+    </request>
+  </interface>
+</protocol>

--- a/src/ws-eglstream.cpp
+++ b/src/ws-eglstream.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ws-eglstream.h"
+
+#include "wayland-eglstream-controller-server-protocol.h"
+#include <cassert>
+#include <epoxy/egl.h>
+
+#ifndef EGL_WL_bind_wayland_display
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
+#endif
+
+namespace WS {
+
+static PFNEGLBINDWAYLANDDISPLAYWL s_eglBindWaylandDisplayWL;
+
+static const struct wl_eglstream_controller_interface s_eglstreamControllerInterface = {
+    // attach_eglstream_consumer
+    [](struct wl_client*, struct wl_resource*, struct wl_resource* surfaceResource, struct wl_resource* bufferResource)
+    {
+        auto& surface = *static_cast<Surface*>(wl_resource_get_user_data(surfaceResource));
+
+        if (surface.exportableClient)
+            surface.exportableClient->exportEGLStreamProducer(bufferResource);
+    },
+    // attach_eglstream_consumer_attribs
+    [](struct wl_client*, struct wl_resource*, struct wl_resource* surfaceResource, struct wl_resource* bufferResource, struct wl_array* attribs)
+    {
+        auto& surface = *static_cast<Surface*>(wl_resource_get_user_data(surfaceResource));
+
+        if (surface.exportableClient)
+            surface.exportableClient->exportEGLStreamProducer(bufferResource);
+    },
+};
+
+ImplEGLStream::ImplEGLStream() = default;
+
+ImplEGLStream::~ImplEGLStream()
+{
+    if (m_eglstreamController)
+        wl_global_destroy(m_eglstreamController);
+}
+
+void ImplEGLStream::surfaceAttach(Surface& surface, struct wl_resource* bufferResource)
+{
+    if (surface.bufferResource)
+        wl_buffer_send_release(surface.bufferResource);
+    surface.bufferResource = bufferResource;
+}
+
+void ImplEGLStream::surfaceCommit(Surface& surface)
+{
+    if (!surface.exportableClient)
+        return;
+
+    struct wl_resource* bufferResource = surface.bufferResource;
+    surface.bufferResource = nullptr;
+
+    surface.exportableClient->exportBufferResource(bufferResource);
+}
+
+bool ImplEGLStream::initialize(EGLDisplay eglDisplay)
+{
+    m_eglstreamController = wl_global_create(display(), &wl_eglstream_controller_interface, 2, this,
+        [](struct wl_client* client, void*, uint32_t version, uint32_t id)
+        {
+            struct wl_resource* resource = wl_resource_create(client, &wl_eglstream_controller_interface, version, id);
+            if (!resource) {
+                wl_client_post_no_memory(client);
+                return;
+            }
+
+            wl_resource_set_implementation(resource, &s_eglstreamControllerInterface, nullptr, nullptr);
+        });
+
+    s_eglBindWaylandDisplayWL = reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(eglGetProcAddress("eglBindWaylandDisplayWL"));
+    if (!s_eglBindWaylandDisplayWL || !s_eglBindWaylandDisplayWL(eglDisplay, display()))
+        return false;
+
+    m_initialized = true;
+    return true;
+}
+
+} // namespace WS

--- a/src/ws-eglstream.h
+++ b/src/ws-eglstream.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ws.h"
+
+typedef void *EGLDisplay;
+
+namespace WS {
+
+class ImplEGLStream final : public Instance::Impl {
+public:
+    ImplEGLStream();
+    virtual ~ImplEGLStream();
+
+    Type type() const override { return Instance::Impl::Type::EGLStream; }
+    bool initialized() const override { return m_initialized; }
+
+    void surfaceAttach(Surface&, struct wl_resource*) override;
+    void surfaceCommit(Surface&) override;
+
+    bool initialize(EGLDisplay);
+
+private:
+    bool m_initialized { false };
+
+    struct wl_global* m_eglstreamController { nullptr };
+};
+
+} // namespace WS

--- a/src/ws.h
+++ b/src/ws.h
@@ -43,6 +43,7 @@ struct ExportableClient {
     virtual void exportBufferResource(struct wl_resource*) = 0;
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
+    virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
 };
 
 struct Surface;
@@ -63,6 +64,7 @@ public:
     public:
         enum class Type {
             EGL,
+            EGLStream,
             SHM,
         };
 


### PR DESCRIPTION
Add initial support for the EGLStream buffer sharing mechanism that's
most prominently implemented in NVIDIA graphics stacks.

Existing integration of the EGLStream and the Wayland IPC mechanism
allows the client behavior to remain unchanged, meaning the Wayland
EGL platform can still be used. For this to work, we are required to
provide a `wl_eglstream_controller` object on the internal server.
This is done when `wpe_fdo_initialize_eglstream()` is invoked.

The resulting Wayland resources are exported to the user through the
new EGLStream-oriented interface, `wpe_view_backend_exportable_fdo_eglstream_client`.
`export_eglstream_producer_resource()` provides the wl_resource
object from which the user is required to extract the EGLStream
producer and immediately associate it with an EGLStream consumer.
The callback can be invoked multiple times for the same view, e.g.
a new EGLStream is produced for each change in view's size.

The `notify_eglstream_frame()` is a simple callback that signals
whenever a new frame is available on the EGLStream, allowing the user
to put the EGLStream consumer to work.

The new mode doesn't impose additional dependencies, but the
implementation and the related APIs are still subject to change.