### PR TITLE
renderer-backend-egl: cast return value in get_native_display()

### DIFF
--- a/src/renderer-backend-egl.cpp
+++ b/src/renderer-backend-egl.cpp
@@ -98,7 +98,7 @@ struct wpe_renderer_backend_egl_interface fdo_renderer_backend_egl = {
     [](void* data) -> EGLNativeDisplayType
     {
         auto& backend = *reinterpret_cast<Backend*>(data);
-        return backend.display();
+        return EGLNativeDisplayType(backend.display());
     },
 };
 


### PR DESCRIPTION
In the wpe_renderer_backend_egl_interface::get_native_display(),
explicitly cast the wl_display object to the EGLNativeDisplayType.
This should avoid compilation errors on rare EGL stacks that have
odd default EGLNativeDisplayType type definitions.