### PR TITLE
cmake: use add_definitions instead of add_compile_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,11 @@ find_package(Wayland REQUIRED client server egl)
 find_package(WaylandScanner REQUIRED)
 find_package(WPE 1.5.90 REQUIRED)
 
-add_compile_definitions(
-    WPE_FDO_COMPILATION
-    G_LOG_DOMAIN=\"WPE-FDO\"
-    _FILE_OFFSET_BITS=64
-    _LARGEFILE64_SOURCE=1
+add_definitions(
+    -DWPE_FDO_COMPILATION
+    -DG_LOG_DOMAIN=\"WPE-FDO\"
+    -D_FILE_OFFSET_BITS=64
+    -D_LARGEFILE64_SOURCE=1
 )
 
 configure_file(include/wpe/version.h.cmake "${CMAKE_BINARY_DIR}/version.h" @ONLY)


### PR DESCRIPTION
* `add_compile_definitions()` requires CMake 3.12, but Ubuntu-18.04 ships CMake 3.10. This fixes the build for old CMake versions.
* Noticed this on one of the packaging bots that [failed to build WPEBackend-fdo after updating it](https://build.webkit.org/builders/GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804/builds/58/steps/jhbuild/logs/stdio)