### PR TITLE
view-backend-exportable-private: Add wl_client_add_destroy_listener in the ViewBackend

### DIFF
--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -127,19 +127,19 @@ void ViewBackend::registerSurface(uint32_t surfaceId)
 {
     m_surfaceId = surfaceId;
     m_client = WS::Instance::singleton().registerViewBackend(m_surfaceId, *this);
-    this->m_destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
+ 
+    struct wl_client_destroy_listener *listener = new wl_client_destroy_listener {this, };
+    listener->destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
     {
-        ViewBackend *viewBackend;
-        viewBackend = wl_container_of(listener, viewBackend, m_destroyClientListener);
+        struct wl_client_destroy_listener *container;
+        container = wl_container_of(listener, container, destroyClientListener);
 
         struct wl_client* client = (struct wl_client*) data;
-        g_debug("ViewBackend <%p>: wl_client <%p> destroy notification for fd %d", viewBackend, data, wl_client_get_fd(client));
-        viewBackend->m_client = NULL;
+        container->backend->m_client = NULL;
+        delete container;  // Release the wl_client_destroy_listener instance since this is not longer needed.
     };
     wl_client_add_destroy_listener(m_client,
-                                   &this->m_destroyClientListener);
-
-
+                                   &listener->destroyClientListener);
 }
 
 void ViewBackend::unregisterSurface(uint32_t surfaceId)

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -100,7 +100,11 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
-    struct wl_listener m_destroyClientListener;
+};
+
+struct wl_client_destroy_listener {
+    ViewBackend* backend;
+    struct wl_listener destroyClientListener;
 };
 
 struct wpe_view_backend_private {

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -100,6 +100,7 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
+    struct wl_listener m_destroyClientListener;
 };
 
 struct wpe_view_backend_private {

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -91,7 +91,12 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_surfaceId { 0 };
-    struct wl_client* m_client { nullptr };
+    struct Client {
+        struct wl_client* object { nullptr };
+        struct wl_listener destroyListener;
+
+        static void destroyNotify(struct wl_listener*, void*);
+    } m_client;
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
@@ -100,11 +105,6 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
-};
-
-struct wl_client_destroy_listener {
-    ViewBackend* backend;
-    struct wl_listener destroyClientListener;
 };
 
 struct wpe_view_backend_private {

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -532,6 +532,7 @@ void Instance::unregisterViewBackend(uint32_t surfaceId)
     auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
+        wl_client_destroy(it->second->client);
         m_viewBackendMap.erase(it);
     }
 }


### PR DESCRIPTION
**DESCRIPTION:**

This MR fixes a crash in the WebKit UI-process. This crash happens when the wl_client of the related to a surface of a blocked content loaded request is being closed because an WL_EVENT_HANGUP (5).

In this scenario, the UI-process doesn't know about this client being closed and because it has its own copy of the wl_client pointer it keeps trying to operate over it during the release/dispatch actions. Therefore, the client is being freed in the wayland code when the error happens but the ViewBackend will never will know that its copy of the pointer is pointing to an area that it will be deleted.

The WL_EVENT_HANGUP happens immediately after that the content is blocked. If we are able to close the client and/or unregister the surface related to this request in a civilized way, we could avoid this situation.

**HOW TO REPRODUCE the bug:**

The synthetic code to reproduce the crash is attached in the issue: [launcher.c](https://bugs.webkit.org/attachment.cgi?id=413286)

* Build instructions:

```
# Set this variables to the right place where you have the WPE related libraries
# export PKG_CONFIG_PATH=/home/igalia/psaavedra/install/lib/pkgconfig/
# export LD_LIBRARY_PATH=/home/igalia/psaavedra/install/lib

filename="launcher"

CFLAGS="gtk+-3.0 wpe-webkit-1.0 wpebackend-fdo-1.0 egl"
LIBS="gtk+-3.0 wayland-client wpe-1.0 wpebackend-fdo-1.0 wpe-web-extension-1.0  wpe-webkit-1.0 egl"

gcc -g3 `pkg-config --cflags $CFLAGS` -o $filename $filename.c `pkg-config --libs $LIBS`
```

* Execution: 

```
export WAYLAND_DISPLAY=wayland-0
export XDG_RUNTIME_DIR=/xdg
export LD_LIBRARY_PATH=/home/igalia/psaavedra/install/lib
export WEBKIT_IGNORE_SSL_ERRORS=1
./launcher
```

The issue is reproducible in:

* WebKit: 2.28; 2.30; trunk (2020-11-05)
* libwpe: 1.6; 1.8
* Weston: 1.3; 5.0 
* Wayland-protocols: 1.13 and 1.17

```
ii  wayland-protocols                      1.17-1                              all          wayland compositor protocols
ii  weston                                 5.0.0-3                             amd64        reference implementation of a wayland compositor
```

**SOLUTION:**

This MR is attempts to address this issue by:

* Add callback for wl_client_add_destroy_listener in the ViewBackend.This callback set the m_client to null.
* Guard the wl_client_flush() calls when wayland client object reference is null.

Ref: [[WPE] Crash if a view loads a blocked URL by a content filter - webkit#218612](https://bugs.webkit.org/show_bug.cgi?id=218612)


Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
