### PR TITLE
meson: Only add a wayland-egl dependency if needed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -244,9 +244,40 @@ deps = [
 	dependency('gobject-2.0'),
 	dependency('wayland-client'),
 	dependency('wayland-server'),
-	dependency('wayland-egl'),
 	dependency('wpe-1.0', version: '>=1.6.0', fallback: ['libwpe', 'libwpe_dep']),
 ]
+
+# Will be set to the library dependency which provides the wl_egl_* functions.
+wl_egl_dep = disabler()
+
+# Some EGL drivers provide the wl_egl_* symbols directly (e.g. old versions
+# of the Vivante driver), instead of a wayland-egl library. Try both and use
+# the first one found.
+wl_egl_try_deps = ['wayland-egl', 'egl']
+foreach dep_name : wl_egl_try_deps
+	dep = dependency(dep_name, required: false)
+	if dep.found() and cxx.has_function('wl_egl_window_create', dependencies: dep)
+		wl_egl_dep = dep
+		break
+	endif
+endforeach
+
+# As a fall back for systems which have an EGL library without a corresponding
+# pkg-config module, try findind the library directly.
+if not wl_egl_dep.found()
+	dep = cxx.find_library('EGL', required: false)
+	if dep.found() and cxx.has_function('wl_egl_window_create', dependencies: dep)
+		wl_egl_dep = dep
+	endif
+endif
+
+if wl_egl_dep.found()
+	deps += [wl_egl_dep]
+else
+	warning('''
+	Could not check availability of the wl_egl_* functions (tried wayland-client,
+	egl, and libEGL). Continuing anyway, but your build will likely be broken.''')
+endif
 
 xkbcommon_dep = dependency('xkbcommon', required: false)
 if xkbcommon_dep.found()


### PR DESCRIPTION
Some drivers provide the `wl_egl_*` symbols their EGL library (either directly or indirectly in some other one needed by it) and do not ship a `wayland-egl` library. In that case, checking for `wayland-egl` fails even if the symbols are usable. To accomodate for this, check whether `wl_egl_create_window` is usable before trying to add the dependency on `wayland-egl`.

----

Idea from https://github.com/Igalia/cog/commit/170e3ef9d and also a patch proposed by @psaavedra (thanks!)