### PR TITLE
Add unstable dmabuf-pool API

### DIFF
--- a/include/wpe/unstable/dmabuf-pool-entry.h
+++ b/include/wpe/unstable/dmabuf-pool-entry.h
@@ -23,65 +23,44 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#if !defined(__WPE_FDO_DMABUF_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/unstable/fdo-dmabuf.h> can be included directly."
+#endif
 
-#include "egl-client-wayland.h"
+#pragma once
 
-#include "ws-client.h"
+#include <stdint.h>
 
-namespace WS {
-namespace EGLClient {
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
-{
+struct wpe_dmabuf_pool_entry;
+
+struct wpe_dmabuf_pool_entry_init {
+    uint32_t width;
+    uint32_t height;
+    uint32_t format;
+
+    unsigned num_planes;
+    int fds[4];
+    uint32_t strides[4];
+    uint32_t offsets[4];
+    uint64_t modifiers[4];
+};
+
+struct wpe_dmabuf_pool_entry*
+wpe_dmabuf_pool_entry_create(const struct wpe_dmabuf_pool_entry_init*);
+
+void
+wpe_dmabuf_pool_entry_destroy(struct wpe_dmabuf_pool_entry*);
+
+void
+wpe_dmabuf_pool_entry_set_user_data(struct wpe_dmabuf_pool_entry*, void*);
+
+void*
+wpe_dmabuf_pool_entry_get_user_data(struct wpe_dmabuf_pool_entry*);
+
+#ifdef __cplusplus
 }
-
-BackendWayland::~BackendWayland() = default;
-
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
-}
-
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
-
-
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
-
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient
+#endif

--- a/include/wpe/unstable/fdo-dmabuf.h
+++ b/include/wpe/unstable/fdo-dmabuf.h
@@ -23,65 +23,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#ifdef __WEBKIT_WEB_EXTENSION_H__
+#error "Headers <wpe/unstable/fdo-dmabuf.h> and <wpe/webkit-web-extension.h> cannot be included together."
+#endif
 
-#include "egl-client-wayland.h"
+#pragma once
 
-#include "ws-client.h"
+#define __WPE_FDO_DMABUF_H_INSIDE__
 
-namespace WS {
-namespace EGLClient {
+#include "dmabuf-pool-entry.h"
+#include "initialize-dmabuf.h"
+#include "view-backend-dmabuf-pool-fdo.h"
 
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
-{
-}
-
-BackendWayland::~BackendWayland() = default;
-
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
-}
-
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
-
-
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
-
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient
+#undef __WPE_FDO_DMABUF_H_INSIDE__

--- a/include/wpe/unstable/initialize-dmabuf.h
+++ b/include/wpe/unstable/initialize-dmabuf.h
@@ -23,65 +23,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#if !defined(__WPE_FDO_DMABUF_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/unstable/fdo-dmabuf.h> can be included directly."
+#endif
 
-#include "egl-client-wayland.h"
+#pragma once
 
-#include "ws-client.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-namespace WS {
-namespace EGLClient {
+#include <stdbool.h>
 
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
-{
+bool
+wpe_fdo_initialize_dmabuf(void);
+
+#ifdef __cplusplus
 }
-
-BackendWayland::~BackendWayland() = default;
-
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
-}
-
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
-
-
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
-
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient
+#endif

--- a/include/wpe/unstable/view-backend-dmabuf-pool-fdo.h
+++ b/include/wpe/unstable/view-backend-dmabuf-pool-fdo.h
@@ -23,65 +23,46 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#if !defined(__WPE_FDO_DMABUF_H_INSIDE__) && !defined(WPE_FDO_COMPILATION)
+#error "Only <wpe/unstable/fdo-dmabuf.h> can be included directly."
+#endif
 
-#include "egl-client-wayland.h"
+#pragma once
 
-#include "ws-client.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-namespace WS {
-namespace EGLClient {
+#include <wpe/wpe.h>
 
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
-{
+struct wpe_dmabuf_pool_entry;
+
+struct wpe_view_backend_dmabuf_pool_fdo_client {
+    struct wpe_dmabuf_pool_entry* (*create_entry)(void*);
+    void (*destroy_entry)(void*, struct wpe_dmabuf_pool_entry*);
+    void (*commit_entry)(void*, struct wpe_dmabuf_pool_entry*);
+
+    void (*_wpe_reserved0)(void);
+    void (*_wpe_reserved1)(void);
+    void (*_wpe_reserved2)(void);
+    void (*_wpe_reserved3)(void);
+};
+
+struct wpe_view_backend_dmabuf_pool_fdo*
+wpe_view_backend_dmabuf_pool_fdo_create(const struct wpe_view_backend_dmabuf_pool_fdo_client*, void*, uint32_t width, uint32_t height);
+
+void
+wpe_view_backend_dmabuf_pool_fdo_destroy(struct wpe_view_backend_dmabuf_pool_fdo*);
+
+struct wpe_view_backend*
+wpe_view_backend_dmabuf_pool_fdo_get_view_backend(struct wpe_view_backend_dmabuf_pool_fdo*);
+
+void
+wpe_view_backend_dmabuf_pool_fdo_dispatch_frame_complete(struct wpe_view_backend_dmabuf_pool_fdo*);
+
+void
+wpe_view_backend_dmabuf_pool_fdo_dispatch_release_entry(struct wpe_view_backend_dmabuf_pool_fdo*, struct wpe_dmabuf_pool_entry*);
+
+#ifdef __cplusplus
 }
-
-BackendWayland::~BackendWayland() = default;
-
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
-}
-
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
-
-
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
-
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient
+#endif

--- a/meson.build
+++ b/meson.build
@@ -32,10 +32,13 @@ soversion_micro = soversion[1]  # Revision
 soversion = '@0@.@1@.@2@'.format(soversion_major, soversion_minor, soversion_micro)
 
 sources = [
+	'src/dmabuf-pool-entry.cpp',
+	'src/egl-client-dmabuf-pool.cpp',
 	'src/egl-client-wayland.cpp',
 	'src/exported-buffer-shm.cpp',
 	'src/exported-image-egl.cpp',
 	'src/fdo.cpp',
+	'src/initialize-dmabuf.cpp',
 	'src/initialize-egl.cpp',
 	'src/initialize-eglstream.cpp',
 	'src/initialize-shm.cpp',
@@ -43,12 +46,14 @@ sources = [
 	'src/renderer-backend-egl.cpp',
 	'src/renderer-host.cpp',
 	'src/version.c',
+	'src/view-backend-dmabuf-pool-fdo.cpp',
 	'src/view-backend-exportable-fdo.cpp',
 	'src/view-backend-exportable-fdo-egl.cpp',
 	'src/view-backend-exportable-fdo-eglstream.cpp',
 	'src/view-backend-private.cpp',
 	'src/ws.cpp',
 	'src/ws-client.cpp',
+	'src/ws-dmabuf-pool.cpp',
 	'src/ws-egl.cpp',
 	'src/ws-eglstream.cpp',
 	'src/ws-shm.cpp',
@@ -78,10 +83,14 @@ extensions_api_headers = [
 ]
 
 unstable_api_headers = [
+	'include/wpe/unstable/dmabuf-pool-entry.h',
+	'include/wpe/unstable/fdo-dmabuf.h',
 	'include/wpe/unstable/fdo-eglstream.h',
 	'include/wpe/unstable/fdo-shm.h',
+	'include/wpe/unstable/initialize-dmabuf.h',
 	'include/wpe/unstable/initialize-shm.h',
 	'include/wpe/unstable/initialize-eglstream.h',
+	'include/wpe/unstable/view-backend-dmabuf-pool-fdo.h',
 	'include/wpe/unstable/view-backend-exportable-eglstream.h',
 ]
 
@@ -196,6 +205,26 @@ wayland_eglstream_controller_proto_source = custom_target(
 	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
 )
 
+# Wayland extension: dmabuf pool
+wpe_dmabuf_pool_client_proto_header = custom_target(
+	'dmabuf-pool-client-proto-header',
+	input: 'src/dmabuf-pool/wpe-dmabuf-pool.xml',
+	output: '@BASENAME@-client-protocol.h',
+	command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_dmabuf_pool_server_proto_header = custom_target(
+	'dmabuf-pool-server-proto-header',
+	input: 'src/dmabuf-pool/wpe-dmabuf-pool.xml',
+	output: '@BASENAME@-server-protocol.h',
+	command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+wpe_dmabuf_pool_proto_source = custom_target(
+	'dmabuf-pool-proto-source',
+	input: 'src/dmabuf-pool/wpe-dmabuf-pool.xml',
+	output: '@BASENAME@-protocol.c',
+	command: [wayland_scanner, wayland_scanner_code, '@INPUT@', '@OUTPUT@'],
+)
+
 cxx = meson.get_compiler('cpp')
 
 # Switch to the 'cpp_eh=none' default option when updating to Meson 0.51 or newer, see
@@ -285,6 +314,9 @@ generated_sources = [
 	wpe_video_plane_display_dmabuf_server_proto_header,
 	wayland_eglstream_controller_proto_source,
 	wayland_eglstream_controller_server_proto_header,
+	wpe_dmabuf_pool_client_proto_header,
+	wpe_dmabuf_pool_server_proto_header,
+	wpe_dmabuf_pool_proto_source,
 ]
 
 lib = shared_library('WPEBackend-fdo-' + api_version,

--- a/src/bridge/wpe-bridge.xml
+++ b/src/bridge/wpe-bridge.xml
@@ -29,6 +29,7 @@
   <interface name="wpe_bridge" version="1">
     <enum name="client_implementation_type">
       <entry name="wayland" value="0"/>
+      <entry name="dmabuf_pool" value="1"/>
     </enum>
 
     <request name="initialize">

--- a/src/dmabuf-pool-entry-private.h
+++ b/src/dmabuf-pool-entry-private.h
@@ -23,65 +23,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#pragma once
 
-#include "egl-client-wayland.h"
+#include "wpe/unstable/dmabuf-pool-entry.h"
 
-#include "ws-client.h"
+#include <array>
 
-namespace WS {
-namespace EGLClient {
+struct wl_resource;
 
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
-{
-}
+struct wpe_dmabuf_pool_entry {
+    struct wl_resource* bufferResource { nullptr };
 
-BackendWayland::~BackendWayland() = default;
+    void* data { nullptr };
 
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
-}
+    uint32_t width { 0 };
+    uint32_t height { 0 };
+    uint32_t format { 0 };
 
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
-
-
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
-
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient
+    unsigned num_planes { 0 };
+    std::array<int, 4> fds { -1, -1, -1, -1 };
+    std::array<uint32_t, 4> strides { };
+    std::array<uint32_t, 4> offsets { };
+    std::array<uint64_t, 4> modifiers { };
+};

--- a/src/dmabuf-pool/wpe-dmabuf-pool.xml
+++ b/src/dmabuf-pool/wpe-dmabuf-pool.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wpe_dmabuf_pool">
+  <copyright>
+    Copyright © 2020 Igalia S.L.
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="wpe_dmabuf_pool_manager" version="1">
+    <request name="create_pool">
+      <arg name="id" type="new_id" interface="wpe_dmabuf_pool"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+  </interface>
+
+  <interface name="wpe_dmabuf_pool" version="1">
+    <request name="create_buffer">
+      <arg name="buffer_id" type="new_id" interface="wl_buffer"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="get_dmabuf_data">
+      <arg name="dmabuf_data_id" type="new_id" interface="wpe_dmabuf_data"/>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+    </request>
+  </interface>
+
+  <interface name="wpe_dmabuf_data" version="1">
+    <request name="request">
+    </request>
+
+    <event name="attributes">
+      <arg name="width" type="uint" />
+      <arg name="height" type="uint" />
+      <arg name="format" type="uint" />
+      <arg name="num_planes" type="uint" />
+    </event>
+
+    <event name="plane">
+      <arg name="id" type="uint" />
+      <arg name="fd" type="fd" />
+      <arg name="stride" type="uint" />
+      <arg name="offset" type="uint" />
+      <arg name="modifier_hi" type="uint" />
+      <arg name="modifier_lo" type="uint" />
+    </event>
+
+    <event name="complete">
+    </event>
+  </interface>
+</protocol>

--- a/src/egl-client-dmabuf-pool.cpp
+++ b/src/egl-client-dmabuf-pool.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "egl-client-dmabuf-pool.h"
+
+#include "ws-client.h"
+
+#include <array>
+#include <cstdio>
+
+namespace WS {
+namespace EGLClient {
+
+BackendDmabufPool::BackendDmabufPool(BaseBackend&)
+{
+}
+
+BackendDmabufPool::~BackendDmabufPool() = default;
+
+EGLNativeDisplayType BackendDmabufPool::nativeDisplay() const
+{
+    return EGL_DEFAULT_DISPLAY;
+}
+
+uint32_t BackendDmabufPool::platform() const
+{
+    return EGL_PLATFORM_SURFACELESS_MESA;
+}
+
+
+struct TargetDmabufPool::Buffer {
+    struct wl_list link;
+    struct wl_buffer* buffer { nullptr };
+    bool locked { false };
+
+    struct {
+        uint32_t width;
+        uint32_t height;
+        uint32_t format;
+    } meta;
+
+    struct {
+        EGLImageKHR image;
+    } egl;
+
+    struct {
+        GLuint colorBuffer;
+        GLuint dsBuffer;
+    } gl;
+};
+
+struct BufferData {
+    bool complete { false };
+
+    uint32_t width { 0 };
+    uint32_t height { 0 };
+    uint32_t format { 0 };
+
+    uint32_t numPlanes { 0 };
+    std::array<int, 4> fds { -1, -1, -1, -1 };
+    std::array<uint32_t, 4> strides { };
+    std::array<uint32_t, 4> offsets { };
+    std::array<uint64_t, 4> modifiers { };
+};
+
+TargetDmabufPool::TargetDmabufPool(BaseTarget& base, uint32_t width, uint32_t height)
+    : m_base(base)
+{
+    wl_list_init(&m_buffer.list);
+
+    m_renderer.width = width;
+    m_renderer.height = height;
+}
+
+TargetDmabufPool::~TargetDmabufPool() = default;
+
+EGLNativeWindowType TargetDmabufPool::nativeWindow() const
+{
+    return 0;
+}
+
+void TargetDmabufPool::resize(uint32_t width, uint32_t height)
+{
+    if (m_renderer.width == width && m_renderer.height == height)
+        return;
+
+    m_renderer.width = width;
+    m_renderer.height = height;
+
+    m_buffer.current = nullptr;
+
+    Buffer* buffer;
+    Buffer* tmp;
+    wl_list_for_each_safe(buffer, tmp, &m_buffer.list, link) {
+        wl_list_remove(&buffer->link);
+        destroyBuffer(buffer);
+    }
+    wl_list_init(&m_buffer.list);
+}
+
+void TargetDmabufPool::frameWillRender()
+{
+    if (!m_renderer.initialized) {
+        m_renderer.initialized = true;
+
+        m_renderer.createImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
+            eglGetProcAddress("eglCreateImageKHR"));
+        m_renderer.destroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(
+            eglGetProcAddress("eglDestroyImageKHR"));
+        m_renderer.imageTargetRenderbufferStorageOES = reinterpret_cast<PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC>(
+            eglGetProcAddress("glEGLImageTargetRenderbufferStorageOES"));
+
+        GLuint framebuffer { 0 };
+        glGenFramebuffers(1, &framebuffer);
+        m_renderer.framebuffer = framebuffer;
+    }
+
+    m_base.requestFrame();
+
+    g_assert(!m_buffer.current);
+    {
+        Buffer* b;
+        wl_list_for_each(b, &m_buffer.list, link) {
+            if (b->locked)
+                continue;
+
+            m_buffer.current = b;
+            break;
+        }
+    }
+    if (!m_buffer.current) {
+        auto* buffer = new Buffer;
+        buffer->buffer = wpe_dmabuf_pool_create_buffer(m_base.wpeDmabufPool(), m_renderer.width, m_renderer.height);
+        wl_buffer_add_listener(buffer->buffer, &s_bufferListener, this);
+
+        wl_list_insert(&m_buffer.list, &buffer->link);
+        m_buffer.current = buffer;
+
+        struct wpe_dmabuf_data* dmabufData = wpe_dmabuf_pool_get_dmabuf_data(m_base.wpeDmabufPool(), buffer->buffer);
+        wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(dmabufData), m_base.eventQueue());
+
+        BufferData bufferData;
+        wpe_dmabuf_data_add_listener(dmabufData, &s_dmabufDataListener, &bufferData);
+        wpe_dmabuf_data_request(dmabufData);
+        wl_display_roundtrip_queue(m_base.display(), m_base.eventQueue());
+
+        buffer->meta.width = bufferData.width;
+        buffer->meta.height = bufferData.height;
+        buffer->meta.format = bufferData.format;
+
+        std::array<EGLint, 64> attributes;
+        {
+            attributes[0] = EGL_WIDTH; attributes[1] = bufferData.width;
+            attributes[2] = EGL_HEIGHT; attributes[3] = bufferData.height;
+            attributes[4] = EGL_LINUX_DRM_FOURCC_EXT; attributes[5] = bufferData.format;
+            unsigned attributesCount = 6;
+
+            if (bufferData.numPlanes >= 1) {
+                uint32_t modifier_hi = bufferData.modifiers[0] >> 32;
+                uint32_t modifier_lo = bufferData.modifiers[0] & 0xFFFFFFFF;
+                std::array<EGLAttrib, 10> planeAttributes = {
+                        EGL_DMA_BUF_PLANE0_FD_EXT, bufferData.fds[0],
+                        EGL_DMA_BUF_PLANE0_PITCH_EXT, bufferData.strides[0],
+                        EGL_DMA_BUF_PLANE0_OFFSET_EXT, bufferData.offsets[0],
+                        EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, modifier_hi,
+                        EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, modifier_lo,
+                    };
+
+                std::copy(planeAttributes.begin(), planeAttributes.end(),
+                    std::next(attributes.begin(), attributesCount));
+                attributesCount += planeAttributes.size();
+            }
+
+            if (bufferData.numPlanes >= 2) {
+                uint32_t modifier_hi = bufferData.modifiers[1] >> 32;
+                uint32_t modifier_lo = bufferData.modifiers[1] & 0xFFFFFFFF;
+                std::array<EGLAttrib, 10> planeAttributes = {
+                        EGL_DMA_BUF_PLANE1_FD_EXT, bufferData.fds[1],
+                        EGL_DMA_BUF_PLANE1_PITCH_EXT, bufferData.strides[1],
+                        EGL_DMA_BUF_PLANE1_OFFSET_EXT, bufferData.offsets[1],
+                        EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT, modifier_hi,
+                        EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT, modifier_lo,
+                    };
+
+                std::copy(planeAttributes.begin(), planeAttributes.end(),
+                    std::next(attributes.begin(), attributesCount));
+                attributesCount += planeAttributes.size();
+            }
+
+            if (bufferData.numPlanes >= 3) {
+                uint32_t modifier_hi = bufferData.modifiers[2] >> 32;
+                uint32_t modifier_lo = bufferData.modifiers[2] & 0xFFFFFFFF;
+                std::array<EGLAttrib, 10> planeAttributes = {
+                        EGL_DMA_BUF_PLANE2_FD_EXT, bufferData.fds[2],
+                        EGL_DMA_BUF_PLANE2_PITCH_EXT, bufferData.strides[2],
+                        EGL_DMA_BUF_PLANE2_OFFSET_EXT, bufferData.offsets[2],
+                        EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT, modifier_hi,
+                        EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT, modifier_lo,
+                    };
+
+                std::copy(planeAttributes.begin(), planeAttributes.end(),
+                    std::next(attributes.begin(), attributesCount));
+                attributesCount += planeAttributes.size();
+            }
+
+            if (bufferData.numPlanes >= 4) {
+                uint32_t modifier_hi = bufferData.modifiers[3] >> 32;
+                uint32_t modifier_lo = bufferData.modifiers[3] & 0xFFFFFFFF;
+                std::array<EGLAttrib, 10> planeAttributes = {
+                        EGL_DMA_BUF_PLANE3_FD_EXT, bufferData.fds[3],
+                        EGL_DMA_BUF_PLANE3_PITCH_EXT, bufferData.strides[3],
+                        EGL_DMA_BUF_PLANE3_OFFSET_EXT, bufferData.offsets[3],
+                        EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT, modifier_hi,
+                        EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT, modifier_lo,
+                    };
+
+                std::copy(planeAttributes.begin(), planeAttributes.end(),
+                    std::next(attributes.begin(), attributesCount));
+                attributesCount += planeAttributes.size();
+            }
+            attributes[attributesCount++] = EGL_NONE;
+        }
+
+        buffer->egl.image = m_renderer.createImageKHR(eglGetCurrentDisplay(),
+            EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes.data());
+
+        for (unsigned i = 0; i < bufferData.numPlanes; ++i) {
+            if (bufferData.fds[i] != -1)
+                close(bufferData.fds[i]);
+        }
+
+        if (buffer->egl.image == EGL_NO_IMAGE_KHR) {
+            g_warning("unable to create EGLImage from the dma-buf data, error %x", eglGetError());
+            return;
+        }
+
+        std::array<GLuint, 2> renderbuffers { 0, 0 };
+        glGenRenderbuffers(2, renderbuffers.data());
+        buffer->gl.colorBuffer = renderbuffers[0];
+        buffer->gl.dsBuffer = renderbuffers[1];
+
+        glBindRenderbuffer(GL_RENDERBUFFER, buffer->gl.colorBuffer);
+        m_renderer.imageTargetRenderbufferStorageOES(GL_RENDERBUFFER, buffer->egl.image);
+
+        glBindRenderbuffer(GL_RENDERBUFFER, buffer->gl.dsBuffer);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, buffer->meta.width, buffer->meta.height);
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_renderer.framebuffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+        GL_RENDERBUFFER, m_buffer.current->gl.colorBuffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+        GL_RENDERBUFFER, m_buffer.current->gl.dsBuffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
+        GL_RENDERBUFFER, m_buffer.current->gl.dsBuffer);
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        g_warning("established framebuffer object is not framebuffer-complete");
+}
+
+void TargetDmabufPool::frameRendered()
+{
+    glFlush();
+
+    wl_surface_attach(m_base.surface(), m_buffer.current->buffer, 0, 0);
+    wl_surface_commit(m_base.surface());
+
+    m_buffer.current->locked = true;
+    m_buffer.current = nullptr;
+}
+
+void TargetDmabufPool::deinitialize()
+{
+    m_buffer.current = nullptr;
+
+    Buffer* buffer;
+    Buffer* tmp;
+    wl_list_for_each_safe(buffer, tmp, &m_buffer.list, link) {
+        wl_list_remove(&buffer->link);
+        destroyBuffer(buffer);
+    }
+    wl_list_init(&m_buffer.list);
+
+    if (m_renderer.framebuffer) {
+        glDeleteFramebuffers(1, &m_renderer.framebuffer);
+        m_renderer.framebuffer = 0;
+    }
+}
+
+void TargetDmabufPool::destroyBuffer(Buffer* buffer)
+{
+    auto& b = *buffer;
+    g_clear_pointer(&b.buffer, wl_buffer_destroy);
+    if (b.gl.colorBuffer)
+        glDeleteRenderbuffers(1, &b.gl.colorBuffer);
+    if (b.gl.dsBuffer)
+        glDeleteRenderbuffers(1, &b.gl.dsBuffer);
+    if (b.egl.image)
+        m_renderer.destroyImageKHR(eglGetCurrentDisplay(), b.egl.image);
+
+    delete buffer;
+}
+
+const struct wpe_dmabuf_data_listener TargetDmabufPool::s_dmabufDataListener = {
+    // atributes
+    [](void* data, struct wpe_dmabuf_data*, uint32_t width, uint32_t height, uint32_t format, uint32_t num_planes)
+    {
+        auto& bufferData = *static_cast<BufferData*>(data);
+        bufferData.width = width;
+        bufferData.height = height;
+        bufferData.format = format;
+        bufferData.numPlanes = num_planes;
+    },
+    // plane
+    [](void* data, struct wpe_dmabuf_data*, uint32_t id, int32_t fd, uint32_t stride, uint32_t offset, uint32_t modifier_hi, uint32_t modifier_lo)
+    {
+        auto& bufferData = *static_cast<BufferData*>(data);
+        bufferData.fds[id] = fd;
+        bufferData.strides[id] = stride;
+        bufferData.offsets[id] = offset;
+        bufferData.modifiers[id] = (uint64_t(modifier_hi) << 32) | uint64_t(modifier_lo);
+    },
+    // done
+    [](void* data, struct wpe_dmabuf_data*)
+    {
+        auto& bufferData = *static_cast<BufferData*>(data);
+        bufferData.complete = true;
+    },
+};
+
+const struct wl_buffer_listener TargetDmabufPool::s_bufferListener = {
+    // release
+    [](void* data, struct wl_buffer* buffer)
+    {
+        auto& target = *static_cast<TargetDmabufPool*>(data);
+
+        Buffer* b;
+        wl_list_for_each(b, &target.m_buffer.list, link) {
+            if (buffer == b->buffer) {
+                b->locked = false;
+                break;
+            }
+        }
+    }
+};
+
+} } // namespace WS::EGLClient

--- a/src/egl-client-dmabuf-pool.h
+++ b/src/egl-client-dmabuf-pool.h
@@ -26,28 +26,26 @@
 #pragma once
 
 #include "egl-client.h"
-
-struct wl_egl_window;
+#include "wpe-dmabuf-pool-client-protocol.h"
+#include <epoxy/egl.h>
+#include <wayland-client.h>
 
 namespace WS {
 namespace EGLClient {
 
-class BackendWayland final : public BackendImpl {
+class BackendDmabufPool final : public BackendImpl {
 public:
-    BackendWayland(BaseBackend&);
-    virtual ~BackendWayland();
+    BackendDmabufPool(BaseBackend&);
+    virtual ~BackendDmabufPool();
 
     EGLNativeDisplayType nativeDisplay() const override;
     uint32_t platform() const override;
-
-private:
-    BaseBackend& m_base;
 };
 
-class TargetWayland final : public TargetImpl {
+class TargetDmabufPool final : public TargetImpl {
 public:
-    TargetWayland(BaseTarget&, uint32_t width, uint32_t height);
-    virtual ~TargetWayland();
+    TargetDmabufPool(BaseTarget&, uint32_t width, uint32_t height);
+    virtual ~TargetDmabufPool();
 
     EGLNativeWindowType nativeWindow() const override;
 
@@ -61,9 +59,28 @@ public:
 private:
     BaseTarget& m_base;
 
+    static const struct wpe_dmabuf_data_listener s_dmabufDataListener;
+    static const struct wl_buffer_listener s_bufferListener;
+
     struct {
-        struct wl_egl_window* window;
-    } m_egl;
+        bool initialized { false };
+        uint32_t width { 0 };
+        uint32_t height { 0 };
+
+        PFNEGLCREATEIMAGEKHRPROC createImageKHR;
+        PFNEGLDESTROYIMAGEKHRPROC destroyImageKHR;
+        PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC imageTargetRenderbufferStorageOES;
+
+        GLuint framebuffer { 0 };
+    } m_renderer;
+
+    struct Buffer;
+    void destroyBuffer(Buffer*);
+
+    struct {
+        Buffer* current { nullptr };
+        struct wl_list list;
+    } m_buffer;
 };
 
 } } // namespace WS::EGLClient

--- a/src/egl-client.h
+++ b/src/egl-client.h
@@ -65,6 +65,8 @@ public:
 
     virtual void frameWillRender() = 0;
     virtual void frameRendered() = 0;
+
+    virtual void deinitialize() = 0;
 };
 
 } } // namespace WS::EGLClient

--- a/src/initialize-dmabuf.cpp
+++ b/src/initialize-dmabuf.cpp
@@ -23,65 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#include "wpe/unstable/initialize-dmabuf.h"
 
-#include "egl-client-wayland.h"
+#include "ws-dmabuf-pool.h"
 
-#include "ws-client.h"
+extern "C" {
 
-namespace WS {
-namespace EGLClient {
-
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
+__attribute__((visibility("default")))
+bool
+wpe_fdo_initialize_dmabuf(void)
 {
+    WS::Instance::construct(std::unique_ptr<WS::ImplDmabufPool>(new WS::ImplDmabufPool));
+
+    auto& instance = WS::Instance::singleton();
+    return static_cast<WS::ImplDmabufPool&>(instance.impl()).initialize();
 }
 
-BackendWayland::~BackendWayland() = default;
-
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
 }
-
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
-
-
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
-
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient

--- a/src/view-backend-dmabuf-pool-fdo.cpp
+++ b/src/view-backend-dmabuf-pool-fdo.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dmabuf-pool-entry-private.h"
+#include "view-backend-private.h"
+#include "wpe/unstable/view-backend-dmabuf-pool-fdo.h"
+
+class ClientBundleDmabufPool final : public ClientBundle {
+public:
+    ClientBundleDmabufPool(const struct wpe_view_backend_dmabuf_pool_fdo_client* _client, void* data, ViewBackend* viewBackend,
+                 uint32_t initialWidth, uint32_t initialHeight)
+        : ClientBundle(data, viewBackend, initialWidth, initialHeight)
+        , client(_client)
+    { }
+
+    virtual ~ClientBundleDmabufPool() { }
+
+    void exportBuffer(struct wl_resource *buffer) override { }
+    void exportBuffer(const struct linux_dmabuf_buffer *dmabuf_buffer) override { }
+    void exportBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override { }
+    void exportEGLStreamProducer(struct wl_resource* bufferResource) override { }
+
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() override
+    {
+        return client->create_entry(data);
+    }
+
+    void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry* entry) override
+    {
+        client->commit_entry(data, entry);
+    }
+
+    void releaseDmabufPoolEntry(struct wpe_dmabuf_pool_entry* entry)
+    {
+        viewBackend->releaseBuffer(entry->bufferResource);
+    }
+
+    const struct wpe_view_backend_dmabuf_pool_fdo_client* client;
+};
+
+extern "C" {
+
+__attribute__((visibility("default")))
+struct wpe_view_backend_dmabuf_pool_fdo*
+wpe_view_backend_dmabuf_pool_fdo_create(const struct wpe_view_backend_dmabuf_pool_fdo_client* client, void* data, uint32_t width, uint32_t height)
+{
+    auto clientBundle = std::unique_ptr<ClientBundleDmabufPool>(new ClientBundleDmabufPool(client, data, nullptr, width, height));
+
+    struct wpe_view_backend* backend = wpe_view_backend_create_with_backend_interface(&view_backend_private_interface, clientBundle.get());
+    return new struct wpe_view_backend_dmabuf_pool_fdo(std::move(clientBundle), backend);
+}
+
+__attribute__((visibility("default")))
+void
+wpe_view_backend_dmabuf_pool_fdo_destroy(struct wpe_view_backend_dmabuf_pool_fdo* exportable)
+{
+    wpe_view_backend_destroy(exportable->backend);
+    delete exportable;
+}
+
+__attribute__((visibility("default")))
+struct wpe_view_backend*
+wpe_view_backend_dmabuf_pool_fdo_get_view_backend(struct wpe_view_backend_dmabuf_pool_fdo* exportable)
+{
+    return exportable->backend;
+}
+
+__attribute__((visibility("default")))
+void
+wpe_view_backend_dmabuf_pool_fdo_dispatch_frame_complete(struct wpe_view_backend_dmabuf_pool_fdo* exportable)
+{
+    exportable->clientBundle->viewBackend->dispatchFrameCallbacks();
+}
+
+__attribute__((visibility("default")))
+void
+wpe_view_backend_dmabuf_pool_fdo_dispatch_release_entry(struct wpe_view_backend_dmabuf_pool_fdo* exportable, struct wpe_dmabuf_pool_entry* entry)
+{
+    reinterpret_cast<ClientBundleDmabufPool*>(exportable->clientBundle.get())->releaseDmabufPoolEntry(entry);
+}
+
+} // extern "C"

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -118,6 +118,17 @@ public:
         assert(!"should not be reached");
     }
 
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() override
+    {
+        assert(!"should not be reached");
+        return nullptr;
+    }
+
+    void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) override
+    {
+        assert(!"should not be reached");
+    }
+
     void releaseImage(EGLImageKHR image)
     {
         BufferResource* matchingResource = nullptr;
@@ -219,6 +230,17 @@ public:
     }
 
     void exportEGLStreamProducer(struct wl_resource* bufferResource) override
+    {
+        assert(!"should not be reached");
+    }
+
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() override
+    {
+        assert(!"should not be reached");
+        return nullptr;
+    }
+
+    void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) override
     {
         assert(!"should not be reached");
     }

--- a/src/view-backend-exportable-fdo-eglstream.cpp
+++ b/src/view-backend-exportable-fdo-eglstream.cpp
@@ -71,6 +71,17 @@ public:
         client->export_eglstream_producer_resource(data, bufferResource);
     }
 
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() override
+    {
+        assert(!"should not be reached");
+        return nullptr;
+    }
+
+    void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) override
+    {
+        assert(!"should not be reached");
+    }
+
     const struct wpe_view_backend_exportable_fdo_eglstream_client* client;
 };
 

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -121,6 +121,17 @@ public:
         assert(!"should not be reached");
     }
 
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() override
+    {
+        assert(!"should not be reached");
+        return nullptr;
+    }
+
+    void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) override
+    {
+        assert(!"should not be reached");
+    }
+
     void releaseBuffer(struct wl_resource* buffer)
     {
         BufferResource* matchingResource = nullptr;

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -92,6 +92,16 @@ void ViewBackend::exportEGLStreamProducer(struct wl_resource* bufferResource)
     m_clientBundle->exportEGLStreamProducer(bufferResource);
 }
 
+struct wpe_dmabuf_pool_entry* ViewBackend::createDmabufPoolEntry()
+{
+    return m_clientBundle->createDmabufPoolEntry();
+}
+
+void ViewBackend::commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry* entry)
+{
+    m_clientBundle->commitDmabufPoolEntry(entry);
+}
+
 void ViewBackend::dispatchFrameCallbacks()
 {
     if (G_LIKELY(!m_bridgeIds.empty())) {

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -51,6 +51,9 @@ public:
     virtual void exportBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) = 0;
     virtual void exportEGLStreamProducer(struct wl_resource *bufferResource) = 0;
 
+    virtual struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() = 0;
+    virtual void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) = 0;
+
     void* data;
     ViewBackend* viewBackend;
     uint32_t initialWidth;
@@ -68,6 +71,9 @@ public:
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
     void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
     void exportEGLStreamProducer(struct wl_resource*) override;
+
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() override;
+    void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) override;
 
     void bridgeConnectionLost(uint32_t id) override
     {
@@ -112,6 +118,13 @@ struct wpe_view_backend_private {
 
 struct wpe_view_backend_exportable_fdo : wpe_view_backend_private {
     wpe_view_backend_exportable_fdo(std::unique_ptr<ClientBundle>&& clientBundle, struct wpe_view_backend* backend)
+        : wpe_view_backend_private(std::move(clientBundle), backend)
+    {
+    }
+};
+
+struct wpe_view_backend_dmabuf_pool_fdo : wpe_view_backend_private {
+    wpe_view_backend_dmabuf_pool_fdo(std::unique_ptr<ClientBundle>&& clientBundle, struct wpe_view_backend* backend)
         : wpe_view_backend_private(std::move(clientBundle), backend)
     {
     }

--- a/src/ws-client.h
+++ b/src/ws-client.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "wpe-bridge-client-protocol.h"
+#include "wpe-dmabuf-pool-client-protocol.h"
 #include "ipc.h"
 #include "ws-types.h"
 #include <glib.h>
@@ -63,7 +64,10 @@ public:
         virtual void dispatchFrameComplete() = 0;
     };
 
+    struct wl_display* display() const { return m_backend->display(); }
+    struct wl_event_queue* eventQueue() const { return m_wl.eventQueue; }
     struct wl_surface* surface() const { return m_wl.surface; }
+    struct wpe_dmabuf_pool* wpeDmabufPool() const { return m_wl.wpeDmabufPool; }
 
     void requestFrame();
 
@@ -82,6 +86,7 @@ private:
     static const struct wpe_bridge_listener s_bridgeListener;
 
     Impl& m_impl;
+    BaseBackend* m_backend { nullptr };
 
     struct {
         std::unique_ptr<FdoIPC::Connection> socket;
@@ -92,9 +97,11 @@ private:
         struct wl_event_queue* eventQueue { nullptr };
         struct wl_compositor* compositor { nullptr };
         struct wpe_bridge* wpeBridge { nullptr };
-        uint32_t wpeBridgeId { 0 };
+        struct wpe_dmabuf_pool_manager* wpeDmabufPoolManager { nullptr };
 
+        uint32_t wpeBridgeId { 0 };
         struct wl_surface* surface { nullptr };
+        struct wpe_dmabuf_pool* wpeDmabufPool { nullptr };
         struct wl_callback* frameCallback { nullptr };
     } m_wl;
 };

--- a/src/ws-dmabuf-pool.h
+++ b/src/ws-dmabuf-pool.h
@@ -23,65 +23,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wayland-egl.h>
+#pragma once
 
-#include "egl-client-wayland.h"
-
-#include "ws-client.h"
+#include "ws.h"
 
 namespace WS {
-namespace EGLClient {
 
-BackendWayland::BackendWayland(BaseBackend& base)
-    : m_base(base)
-{
-}
+class ImplDmabufPool : public Instance::Impl {
+public:
+    ImplDmabufPool();
+    virtual ~ImplDmabufPool();
 
-BackendWayland::~BackendWayland() = default;
+    ImplementationType type() const override { return ImplementationType::DmabufPool; }
+    bool initialized() const override { return m_initialized; }
 
-EGLNativeDisplayType BackendWayland::nativeDisplay() const
-{
-    return m_base.display();
-}
+    void surfaceAttach(Surface&, struct wl_resource*) override;
+    void surfaceCommit(Surface&) override;
 
-uint32_t BackendWayland::platform() const
-{
-    return 0;
-}
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry(Surface&) override;
 
+    bool initialize();
 
-TargetWayland::TargetWayland(BaseTarget& base, uint32_t width, uint32_t height)
-    : m_base(base)
-{
-    m_egl.window = wl_egl_window_create(base.surface(), width, height);
-}
+private:
+    bool m_initialized { false };
+};
 
-TargetWayland::~TargetWayland()
-{
-    g_clear_pointer(&m_egl.window, wl_egl_window_destroy);
-}
-
-EGLNativeWindowType TargetWayland::nativeWindow() const
-{
-    return m_egl.window;
-}
-
-void TargetWayland::resize(uint32_t width, uint32_t height)
-{
-    wl_egl_window_resize(m_egl.window, width, height, 0, 0);
-}
-
-void TargetWayland::frameWillRender()
-{
-    m_base.requestFrame();
-}
-
-void TargetWayland::frameRendered()
-{
-}
-
-void TargetWayland::deinitialize()
-{
-}
-
-} } // namespace WS::EGLClient
+} // namespace WS

--- a/src/ws-egl.h
+++ b/src/ws-egl.h
@@ -44,6 +44,8 @@ public:
     void surfaceAttach(Surface&, struct wl_resource*) override;
     void surfaceCommit(Surface&) override;
 
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry(Surface&) override { return nullptr; }
+
     bool initialize(EGLDisplay);
 
     EGLImageKHR createImage(struct wl_resource*);

--- a/src/ws-eglstream.h
+++ b/src/ws-eglstream.h
@@ -42,6 +42,8 @@ public:
     void surfaceAttach(Surface&, struct wl_resource*) override;
     void surfaceCommit(Surface&) override;
 
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry(Surface&) override { return nullptr; }
+
     bool initialize(EGLDisplay);
 
 private:

--- a/src/ws-shm.h
+++ b/src/ws-shm.h
@@ -40,6 +40,8 @@ public:
     void surfaceAttach(Surface&, struct wl_resource*) override;
     void surfaceCommit(Surface&) override;
 
+    struct wpe_dmabuf_pool_entry* createDmabufPoolEntry(Surface&) override { return nullptr; }
+
     bool initialize();
 
 private:

--- a/src/ws-types.h
+++ b/src/ws-types.h
@@ -28,6 +28,7 @@
 namespace WS {
 
 enum class ImplementationType {
+    DmabufPool,
     EGL,
     EGLStream,
     SHM,
@@ -35,6 +36,7 @@ enum class ImplementationType {
 
 enum class ClientImplementationType {
     Invalid,
+    DmabufPool,
     Wayland,
 };
 

--- a/src/ws.h
+++ b/src/ws.h
@@ -33,6 +33,7 @@
 #include <wayland-server.h>
 
 struct linux_dmabuf_buffer;
+struct wpe_dmabuf_pool_entry;
 struct wpe_video_plane_display_dmabuf_export;
 struct wpe_audio_packet_export;
 
@@ -45,6 +46,9 @@ struct APIClient {
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
     virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
+
+    virtual struct wpe_dmabuf_pool_entry* createDmabufPoolEntry() = 0;
+    virtual void commitDmabufPoolEntry(struct wpe_dmabuf_pool_entry*) = 0;
 
     // Invoked when the association with the surface associated with a given
     // wpe_bridge identifier is no longer valid, typically due to the nested
@@ -128,6 +132,8 @@ public:
         virtual void surfaceAttach(Surface&, struct wl_resource*) = 0;
         virtual void surfaceCommit(Surface&) = 0;
 
+        virtual struct wpe_dmabuf_pool_entry* createDmabufPoolEntry(Surface&) = 0;
+
     private:
         Instance* m_instance { nullptr };
     };
@@ -177,6 +183,7 @@ private:
     struct wl_display* m_display { nullptr };
     struct wl_global* m_compositor { nullptr };
     struct wl_global* m_wpeBridge { nullptr };
+    struct wl_global* m_wpeDmabufPoolManager { nullptr };
     GSource* m_source { nullptr };
 
     // (bridgeId -> Surface)


### PR DESCRIPTION
Introduce wpe_view_backend_dmabuf_pool_fdo, a wpe_view_backend extension that
demands manual dmabuf managemenet from the user.

This approach to buffer management allows for most flexibility in terms of what
kind of dmabuf objects should be used for rendering. It allows for user to
specify in detail the format, multi-planarity and modifier data of the dmabuf
object.

In order to work with such dmabuf objects, the renderer_backend_egl interfaces
have to leverage a new WS::EGLClient implementation that uses custom Wayland
protocols to properly handle dmabuf content across process boundaries. To
correctly render into these objects, we have to leverage the surfaceless EGL
platform, along with importing the dmabuf objects into EGLImages that we then
use as backing resources for renderbuffers used to render a given frame.

For each wpe_view_backend_dmabuf_pool_fdo, the related client (managed by the
user) has to provide callback implementations that handle dmabuf pool entry
management as well as the notification of which dmabuf pool entry has been
committed for display as the content of the related view.

Upon the create_entry callback dispatch on the client, the callback (as provided
by the user) has to return a wpe_dmabuf_pool_entry object that was initialized
with the relevant dmabuf data. Upon the destroy_entry callback dispatch, the
specified object has to be destroyed.

The commit_entry callback dispatch on the client specifies which dmabuf object
should be presented on the screen, containing the most-recent composition of the
corresponding view's content.

The dmabuf pool entry allocations and deallocations are relayed from the
renderer_backend_target_egl implementation. Whenever a new buffer is required
for rendering, the renderer_backend_target_egl will request for a pool entry to
be created, getting back the relevant dmabuf information and spawning necessary
GL resources that are needed to render into that dmabuf. When finished, the
pool entry will be committed, leaving it up to the user to handle the pool entry
as required.

TODO:
  - TargetDmabufPool: cleanup
  - TargetDmabufPool: resizing support