### PR TITLE
Fix ClientBundle leak

### DIFF
--- a/src/view-backend-exportable-fdo-eglstream.cpp
+++ b/src/view-backend-exportable-fdo-eglstream.cpp
@@ -82,14 +82,10 @@ __attribute__((visibility("default")))
 struct wpe_view_backend_exportable_fdo*
 wpe_view_backend_exportable_fdo_eglstream_create(const struct wpe_view_backend_exportable_fdo_eglstream_client* client, void* data, uint32_t width, uint32_t height)
 {
-    auto* clientBundle = new ClientBundleEGLStream(client, data, nullptr, width, height);
-    struct wpe_view_backend* backend = wpe_view_backend_create_with_backend_interface(&view_backend_private_interface, clientBundle);
+    auto clientBundle = std::unique_ptr<ClientBundleEGLStream>(new ClientBundleEGLStream(client, data, nullptr, width, height));
+    struct wpe_view_backend* backend = wpe_view_backend_create_with_backend_interface(&view_backend_private_interface, clientBundle.get());
 
-    auto* exportable = new struct wpe_view_backend_exportable_fdo;
-    exportable->clientBundle = clientBundle;
-    exportable->backend = backend;
-
-    return exportable;
+    return new struct wpe_view_backend_exportable_fdo(std::move(clientBundle), backend);
 }
 
 }

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -171,22 +171,17 @@ __attribute__((visibility("default")))
 struct wpe_view_backend_exportable_fdo*
 wpe_view_backend_exportable_fdo_create(const struct wpe_view_backend_exportable_fdo_client* client, void* data, uint32_t width, uint32_t height)
 {
-    auto* clientBundle = new ClientBundleBuffer(client, data, nullptr, width, height);
+    auto clientBundle = std::unique_ptr<ClientBundleBuffer>(new ClientBundleBuffer(client, data, nullptr, width, height));
 
-    struct wpe_view_backend* backend = wpe_view_backend_create_with_backend_interface(&view_backend_private_interface, clientBundle);
+    struct wpe_view_backend* backend = wpe_view_backend_create_with_backend_interface(&view_backend_private_interface, clientBundle.get());
 
-    auto* exportable = new struct wpe_view_backend_exportable_fdo;
-    exportable->clientBundle = clientBundle;
-    exportable->backend = backend;
-
-    return exportable;
+    return new struct wpe_view_backend_exportable_fdo(std::move(clientBundle), backend);
 }
 
 __attribute__((visibility("default")))
 void
 wpe_view_backend_exportable_fdo_destroy(struct wpe_view_backend_exportable_fdo* exportable)
 {
-    wpe_view_backend_destroy(exportable->backend);
     delete exportable;
 }
 
@@ -208,14 +203,14 @@ __attribute__((visibility("default")))
 void
 wpe_view_backend_exportable_fdo_dispatch_release_buffer(struct wpe_view_backend_exportable_fdo* exportable, struct wl_resource* buffer)
 {
-    static_cast<ClientBundleBuffer*>(exportable->clientBundle)->releaseBuffer(buffer);
+    static_cast<ClientBundleBuffer*>(exportable->clientBundle.get())->releaseBuffer(buffer);
 }
 
 __attribute__((visibility("default")))
 void
 wpe_view_backend_exportable_fdo_dispatch_release_shm_exported_buffer(struct wpe_view_backend_exportable_fdo* exportable, struct wpe_fdo_shm_exported_buffer* buffer)
 {
-    static_cast<ClientBundleBuffer*>(exportable->clientBundle)->releaseBuffer(buffer);
+    static_cast<ClientBundleBuffer*>(exportable->clientBundle.get())->releaseBuffer(buffer);
 }
 
 }

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -103,11 +103,27 @@ private:
 };
 
 struct wpe_view_backend_private {
-    ClientBundle* clientBundle;
-    struct wpe_view_backend* backend;
+    wpe_view_backend_private(std::unique_ptr<ClientBundle>&& clientBundle, struct wpe_view_backend* backend)
+        : clientBundle(std::move(clientBundle))
+        , backend(backend)
+    {
+    }
+
+    ~wpe_view_backend_private()
+    {
+        wpe_view_backend_destroy(backend);
+    }
+
+    std::unique_ptr<ClientBundle> clientBundle;
+    struct wpe_view_backend* backend { nullptr };
 };
 
-struct wpe_view_backend_exportable_fdo : wpe_view_backend_private { };
+struct wpe_view_backend_exportable_fdo : wpe_view_backend_private {
+    wpe_view_backend_exportable_fdo(std::unique_ptr<ClientBundle>&& clientBundle, struct wpe_view_backend* backend)
+        : wpe_view_backend_private(std::move(clientBundle), backend)
+    {
+    }
+};
 
 static struct wpe_view_backend_interface view_backend_private_interface = {
     // create


### PR DESCRIPTION
ClientBundle is created in exportable_fdo create functions but it's not
released when the wpe_view_backend_exportable_fdo struct is destroyed.

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fe5b8aa6647 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.6+0xab647)
    #1 0x7fe59ecd35d7 in wpe_view_backend_exportable_fdo_egl_create ../src/view-backend-exportable-fdo-egl.cpp:292
    #2 0x7fe5aa59cc3f in WebKit::AcceleratedBackingStoreWayland::AcceleratedBackingStoreWayland(WebKit::WebPageProxy&) (libwebkit2gtk-4.0.so.37+0x4315c3f)
    #3 0x7fe5aa59cd4a in WebKit::AcceleratedBackingStoreWayland::create(WebKit::WebPageProxy&) (libwebkit2gtk-4.0.so.37+0x4315d4a)
    #4 0x7fe5aa59b854 in WebKit::AcceleratedBackingStore::create(WebKit::WebPageProxy&) (libwebkit2gtk-4.0.so.37+0x4314854)
    #5 0x7fe5aa2cf711 in webkitWebViewBaseCreateWebPage(_WebKitWebViewBase*, WTF::Ref<API::PageConfiguration, WTF::RawPtrTraits<API::PageConfiguration> >&&) (libwebkit2gtk-4.0.so.37+0x4048711)
    #6 0x7fe5aa23ec58 in webkitWebViewCreatePage(_WebKitWebView*, WTF::Ref<API::PageConfiguration, WTF::RawPtrTraits<API::PageConfiguration> >&&) (libwebkit2gtk-4.0.so.37+0x3fb7c58)
    #7 0x7fe5aa22798a in webkitWebContextCreatePageForWebView(_WebKitWebContext*, _WebKitWebView*, _WebKitUserContentManager*, _WebKitWebView*, _WebKitWebsitePolicies*) (libwebkit2gtk-4.0.so.37+0x3fa098a)
    #8 0x7fe5aa252142 in webkitWebViewConstructed(_GObject*) (libwebkit2gtk-4.0.so.37+0x3fcb142)
    #9 0x7fe59fd43156 in g_object_new_internal ../gobject/gobject.c:1979

Use std::unique_ptr to create the ClientBundle and transfer the
ownership to wpe_view_backend_exportable_fdo struct that now takes both
the ClientBundle and backend as construct parameters and frees the
backend in the destructor.