### PR TITLE
Simplify public headers

### DIFF
--- a/include/wpe/exported-buffer-shm.h
+++ b/include/wpe/exported-buffer-shm.h
@@ -34,11 +34,7 @@
 extern "C" {
 #endif
 
-#include <wpe/wpe.h>
-
 struct wpe_fdo_shm_exported_buffer;
-
-struct wl_resource;
 struct wl_shm_buffer;
 
 struct wl_shm_buffer*

--- a/include/wpe/exported-image-egl.h
+++ b/include/wpe/exported-image-egl.h
@@ -30,11 +30,11 @@
 #ifndef __exported_image_egl_h__
 #define __exported_image_egl_h__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <wpe/wpe.h>
 
 typedef void* EGLImageKHR;
 

--- a/include/wpe/extensions/audio.h
+++ b/include/wpe/extensions/audio.h
@@ -26,6 +26,7 @@
 #ifndef __audio_h__
 #define __audio_h__
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/include/wpe/unstable/fdo-eglstream.h
+++ b/include/wpe/unstable/fdo-eglstream.h
@@ -32,8 +32,8 @@
 
 #define __WPE_FDO_EGLSTREAM_H_INSIDE__
 
-#include <wpe/unstable/initialize-eglstream.h>
-#include <wpe/unstable/view-backend-exportable-eglstream.h>
+#include "initialize-eglstream.h"
+#include "view-backend-exportable-eglstream.h"
 
 #undef __WPE_FDO_EGLSTREAM_H_INSIDE__
 

--- a/include/wpe/unstable/fdo-shm.h
+++ b/include/wpe/unstable/fdo-shm.h
@@ -32,8 +32,8 @@
 
 #define __WPE_FDO_SHM_H_INSIDE__
 
-#include <wpe/exported-buffer-shm.h>
-#include <wpe/unstable/initialize-shm.h>
+#include "../exported-buffer-shm.h"
+#include "initialize-shm.h"
 
 #undef __WPE_FDO_SHM_H_INSIDE__
 

--- a/include/wpe/unstable/view-backend-exportable-eglstream.h
+++ b/include/wpe/unstable/view-backend-exportable-eglstream.h
@@ -30,11 +30,11 @@
 #ifndef __view_backend_exportable_eglstream_h__
 #define __view_backend_exportable_eglstream_h__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <wpe/wpe.h>
 
 struct wl_resource;
 struct wpe_view_backend_exportable_fdo;

--- a/include/wpe/view-backend-exportable-egl.h
+++ b/include/wpe/view-backend-exportable-egl.h
@@ -30,11 +30,11 @@
 #ifndef __view_backend_exportable_egl_h__
 #define __view_backend_exportable_egl_h__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <wpe/wpe.h>
 
 typedef void* EGLImageKHR;
 

--- a/include/wpe/view-backend-exportable.h
+++ b/include/wpe/view-backend-exportable.h
@@ -30,11 +30,11 @@
 #ifndef __view_backend_exportable_h__
 #define __view_backend_exportable_h__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <wpe/wpe.h>
 
 struct wl_resource;
 


### PR DESCRIPTION
Remove unneeded inclusions of libwpe headers, preferring forward declarations of the needed types and make all the inclusions use double quoted paths (to prefer local header versions, as opposed to installed ones).