### PR TITLE
shm: Construct the WS instance once only

### DIFF
--- a/src/initialize-shm.cpp
+++ b/src/initialize-shm.cpp
@@ -33,7 +33,8 @@ __attribute__((visibility("default")))
 bool
 wpe_fdo_initialize_shm(void)
 {
-    WS::Instance::construct(std::unique_ptr<WS::ImplSHM>(new WS::ImplSHM));
+    if (!WS::Instance::isConstructed())
+        WS::Instance::construct(std::unique_ptr<WS::ImplSHM>(new WS::ImplSHM));
 
     auto& instance = WS::Instance::singleton();
     return static_cast<WS::ImplSHM&>(instance.impl()).initialize();


### PR DESCRIPTION
This is consistent with the wpe_fdo_initialize_for_egl_display API. Constructing
one instance per call would lead to wl_display leaks.

The SHM wl_display is now created once only, but remains alive during the
process life-time. A proper deinitialization API might be added later on in
order to give the application full control on the resources life-time.