### PR TITLE
view-backend-exportable-private: use SOCK_CLOEXEC

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -81,7 +81,7 @@ void Connection::send(uint32_t messageId, uint32_t messageBody)
 gboolean Connection::s_socketCallback(GSocket* socket, GIOCondition condition, gpointer data)
 {
     if (!(condition & G_IO_IN))
-                return TRUE;
+        return TRUE;
 
     GError* error = nullptr;
     uint32_t message[2];

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -51,7 +51,7 @@ ViewBackend::~ViewBackend()
 void ViewBackend::initialize()
 {
     int sockets[2];
-    int ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+    int ret = socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sockets);
     if (ret == -1)
         return;
 


### PR DESCRIPTION
I noticed that each time WebKit launches a new web process, the new process has two more sockets open than the previous one. This becomes severe when many web processes are in use simultaneously. In Epiphany, I can open roughly 70 tabs before other things start to go wrong, meaning 140 fds leaked into the final web process.

Turns out we are missing SOCK_CLOEXEC in ViewBackend::initialize, and so the sockets we create here remain open in the child process. Let's fix that.

But wait! Shouldn't the client fd be leaked to the web process? That's why it's created, after all: to allow the UI process to talk to the web process. So why is it OK to use CLOEXEC? Because the actual fd passed to the child process is not the one created in ViewBackend::initialize, but the one created using dup() in ViewBackend::clientFd to copy the one created here. Since we don't pass O_CLOEXEC to dup(), the duped fd will still leak to the child process as before. And WebKit is careful to always close this fd after it launches the web process, so it won't leak to subsequent processes.