### PR TITLE
exported-buffer-shm.h: add a wl_resource getter

### DIFF
--- a/include/wpe/exported-buffer-shm.h
+++ b/include/wpe/exported-buffer-shm.h
@@ -35,7 +35,11 @@ extern "C" {
 #endif
 
 struct wpe_fdo_shm_exported_buffer;
+struct wl_resource;
 struct wl_shm_buffer;
+
+struct wl_resource*
+wpe_fdo_shm_exported_buffer_get_resource(struct wpe_fdo_shm_exported_buffer*);
 
 struct wl_shm_buffer*
 wpe_fdo_shm_exported_buffer_get_shm_buffer(struct wpe_fdo_shm_exported_buffer*);

--- a/src/exported-buffer-shm.cpp
+++ b/src/exported-buffer-shm.cpp
@@ -28,6 +28,13 @@
 extern "C" {
 
 __attribute__((visibility("default")))
+struct wl_resource*
+wpe_fdo_shm_exported_buffer_get_resource(struct wpe_fdo_shm_exported_buffer* buffer)
+{
+    return buffer->resource;
+}
+
+__attribute__((visibility("default")))
 struct wl_shm_buffer*
 wpe_fdo_shm_exported_buffer_get_shm_buffer(struct wpe_fdo_shm_exported_buffer* buffer)
 {


### PR DESCRIPTION
Add the wpe_fdo_shm_exported_buffer_get_resource() entrypoint,
allowing the recepient of the export to also access the wl_resource
object and using that to e.g. attach destroy listeners to that
resource object.