### PR TITLE
Avoid generated version header

### DIFF
--- a/include/wpe/version.h
+++ b/include/wpe/version.h
@@ -30,6 +30,8 @@
 #ifndef __wpe_fdo_version_h__
 #define __wpe_fdo_version_h__
 
+#include "wpebackend-fdo-version.h"
+
 /**
  * WPE_FDO_MAJOR_VERSION:
  *
@@ -47,10 +49,6 @@
  *
  * Micro version of the headers being used at compilation time.
  */
-
-#define WPE_FDO_MAJOR_VERSION (@PROJECT_VERSION_MAJOR@)
-#define WPE_FDO_MINOR_VERSION (@PROJECT_VERSION_MINOR@)
-#define WPE_FDO_MICRO_VERSION (@PROJECT_VERSION_PATCH@)
 
 /**
  * WPE_FDO_CHECK_VERSION:

--- a/include/wpe/wpebackend-fdo-version.h
+++ b/include/wpe/wpebackend-fdo-version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017, 2018 Igalia S.L.
+ * Copyright (C) 2021 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,21 +23,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../include/wpe/initialize-egl.h"
+#ifndef WPEBACKEND_FDO_VERSION_H
+#define WPEBACKEND_FDO_VERSION_H
 
-#include "ws-egl.h"
+#define WPE_FDO_MAJOR_VERSION 1
+#define WPE_FDO_MINOR_VERSION 9
+#define WPE_FDO_MICRO_VERSION 1
 
-extern "C" {
-
-__attribute__((visibility("default")))
-bool
-wpe_fdo_initialize_for_egl_display(EGLDisplay display)
-{
-    if (!WS::Instance::isConstructed())
-        WS::Instance::construct(std::unique_ptr<WS::ImplEGL>(new WS::ImplEGL));
-
-    auto& instance = WS::Instance::singleton();
-    return static_cast<WS::ImplEGL&>(instance.impl()).initialize(display);
-}
-
-}
+#endif /* !WPEBACKEND_FDO_VERSION_H */

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project('wpebackend-fdo', ['c', 'cpp'],
 		'cpp_std=c++11',
 	],
 	license: 'BSD-2-Clause',
-	version: '1.9.1',
+	version: run_command(join_paths('scripts', 'version.py')).stdout().strip(),
 )
 
 # This refers to the API level provided. This is modified only with major,
@@ -23,14 +23,6 @@ api_version = '1.0'
 #   change to [C+1, 0, 0]
 # - If the interface is the same as the previous version, use [C, R+1, A].
 soversion = [8, 1, 7]
-
-# Split the *project* version into its components.
-version_info = meson.project_version().split('.')
-version_info = {
-	'PROJECT_VERSION_MAJOR': version_info[0],
-	'PROJECT_VERSION_MINOR': version_info[1],
-	'PROJECT_VERSION_PATCH': version_info[2],
-}
 
 # Mangle [C, R, A] into an actual usable *soversion*.
 soversion_major = soversion[0] - soversion[2]  # Current-Age
@@ -68,20 +60,15 @@ sources = [
 ]
 
 api_headers = [
-	'include/wpe/exported-image-egl.h',
 	'include/wpe/exported-buffer-shm.h',
-	'include/wpe/initialize-egl.h',
-	'include/wpe/view-backend-exportable.h',
-	'include/wpe/view-backend-exportable-egl.h',
+	'include/wpe/exported-image-egl.h',
 	'include/wpe/fdo-egl.h',
 	'include/wpe/fdo.h',
-
-	# Generated API headers.
-	configure_file(
-		input: 'include/wpe/version.h.in',
-		output: 'version.h',
-		configuration: version_info,
-	),
+	'include/wpe/initialize-egl.h',
+	'include/wpe/version.h',
+	'include/wpe/view-backend-exportable-egl.h',
+	'include/wpe/view-backend-exportable.h',
+	'include/wpe/wpebackend-fdo-version.h',
 ]
 
 extensions_api_headers = [

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2021 Igalia S.L.
+#
+# Distributed under terms of the MIT license.
+
+from os import environ, path
+import re
+
+version = {}
+version_re = re.compile(r"^#define\s+WPE_FDO_([A-Z]+)_VERSION\s+(\d+)$")
+version_file = path.join(environ["MESON_SOURCE_ROOT"],
+                         "include", "wpe", "wpebackend-fdo-version.h")
+
+with open(version_file, "r") as f:
+    for line in f.readlines():
+        m = version_re.match(line)
+        if m:
+            version[m[1]] = m[2]
+
+print("{}.{}.{}".format(version["MAJOR"], version["MINOR"], version["MICRO"]))

--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -23,9 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "../include/wpe/exported-image-egl.h"
 #include "view-backend-exportable-fdo-egl-private.h"
 #include "ws.h"
-#include "wpe/exported-image-egl.h"
 
 #include <cassert>
 

--- a/src/extensions/audio-receiver.cpp
+++ b/src/extensions/audio-receiver.cpp
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe/extensions/audio.h"
+#include "../../include/wpe/extensions/audio.h"
 
 #include "../ws.h"
 #include <unistd.h>

--- a/src/extensions/audio.cpp
+++ b/src/extensions/audio.cpp
@@ -23,10 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe/extensions/audio.h"
+#include "../../include/wpe/extensions/audio.h"
 
-#include "wpe-audio-client-protocol.h"
 #include "../ws-client.h"
+#include "wpe-audio-client-protocol.h"
 #include <wpe/wpe-egl.h>
 #include <cstring>
 

--- a/src/extensions/video-plane-display-dmabuf-receiver.cpp
+++ b/src/extensions/video-plane-display-dmabuf-receiver.cpp
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe/extensions/video-plane-display-dmabuf.h"
+#include "../../include/wpe/extensions/video-plane-display-dmabuf.h"
 
 #include "../ws.h"
 #include <unistd.h>

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -23,10 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe/extensions/video-plane-display-dmabuf.h"
+#include "../../include/wpe/extensions/video-plane-display-dmabuf.h"
 
-#include "wpe-video-plane-display-dmabuf-client-protocol.h"
 #include "../ws-client.h"
+#include "wpe-video-plane-display-dmabuf-client-protocol.h"
 #include <wpe/wpe-egl.h>
 #include <cstring>
 

--- a/src/initialize-eglstream.cpp
+++ b/src/initialize-eglstream.cpp
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe/unstable/initialize-eglstream.h"
+#include "../include/wpe/unstable/initialize-eglstream.h"
 
 #include "ws-eglstream.h"
 

--- a/src/initialize-shm.cpp
+++ b/src/initialize-shm.cpp
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "wpe/unstable/initialize-shm.h"
+#include "../include/wpe/unstable/initialize-shm.h"
 
 #include "ws-shm.h"
 

--- a/src/linux-dmabuf/linux-dmabuf.cpp
+++ b/src/linux-dmabuf/linux-dmabuf.cpp
@@ -3,10 +3,10 @@
  * along with its license.
  */
 
-#include <assert.h>
+#include "../ws-egl.h"
 #include "linux-dmabuf.h"
 #include "linux-dmabuf-unstable-v1-server-protocol.h"
-#include "../ws-egl.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/version.c
+++ b/src/version.c
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "version.h"
+#include "../include/wpe/version.h"
 
 __attribute__((visibility("default")))
 unsigned

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -23,13 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "../include/wpe/view-backend-exportable-egl.h"
+
 #include "exported-buffer-shm-private.h"
 #include "linux-dmabuf/linux-dmabuf.h"
 #include "view-backend-exportable-fdo-egl-private.h"
 #include "view-backend-private.h"
 #include "ws-egl.h"
-#include "wpe/view-backend-exportable-egl.h"
-
 #include <epoxy/egl.h>
 #include <cassert>
 #include <list>

--- a/src/view-backend-exportable-fdo-eglstream.cpp
+++ b/src/view-backend-exportable-fdo-eglstream.cpp
@@ -24,9 +24,9 @@
  */
 
 
+#include "../include/wpe/unstable/view-backend-exportable-eglstream.h"
 #include "view-backend-private.h"
 #include <cassert>
-#include <wpe/unstable/view-backend-exportable-eglstream.h>
 
 namespace {
 

--- a/src/view-backend-exportable-fdo.cpp
+++ b/src/view-backend-exportable-fdo.cpp
@@ -23,11 +23,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "../include/wpe/view-backend-exportable.h"
 #include "exported-buffer-shm-private.h"
 #include "linux-dmabuf/linux-dmabuf.h"
 #include "view-backend-private.h"
 #include "ws.h"
-#include "wpe/view-backend-exportable.h"
 #include <cassert>
 #include <cstring>
 


### PR DESCRIPTION
Use a fixed `wpebackend-fdo-version.h` header which contains `#defines` for the version numbers only, which is the location where the canonical version is read by the build system, and also used by `version.h`, which does not need to be generated anymore.

This avoids needing to use relative `#include` paths, which continued being a pitfall even after the recent improvements due to the mixup of headers with the same name (and relative path!) in the preprocessor search path e.g. `wpe/version.h` from libwpe.

----

This follows the same principle as https://github.com/WebPlatformForEmbedded/libwpe/pull/76