### PR TITLE
view-backend-private: Move wl_client_destroy to unregisterSurface()

### DIFF
--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -139,6 +139,8 @@ void ViewBackend::unregisterSurface(uint32_t surfaceId)
 
     clearFrameCallbacks();
 
+    g_clear_pointer(&m_client.object, wl_client_destroy);
+
     WS::Instance::singleton().unregisterViewBackend(m_surfaceId);
     m_surfaceId = 0;
 }

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -532,7 +532,6 @@ void Instance::unregisterViewBackend(uint32_t surfaceId)
     auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
-        wl_client_destroy(it->second->client);
         m_viewBackendMap.erase(it);
     }
 }


### PR DESCRIPTION
... and add an safeguard to avoid call it twice for the the same wl_client.

This patch is a rework over the original wl_client_destroy added in https://github.com/Igalia/WPEBackend-fdo/pull/127/commits/d086b69397f529ef175ce89909fe443e4f1393dd to avoid crashes like this in https://github.com/Igalia/WPEBackend-fdo/pull/127#discussion_r583508043

This new patch intends to address a new crash introduced by the previous change and identified in https://github.com/Igalia/WPEBackend-fdo/pull/127#discussion_r578492400. This new crash is caused by the unilateral destruction of the `wl_client` in the `Instance::unregisterViewBackend(uint32_t surfaceId)`.

The rationale behind this change is to ensure the `wl_client` is immediately destroyed when the `FdoIPC::Messages::UnregisterSurface` message is received but only if the `wl_client` was not already destroyed in another part of the workflow (ex: a error handling in the `wl_client_connection_data()`).

The destruction of the `wl_client` will inhibit the `wl_event_loop_dispatch()` loop dispatching events for the _wl_sources_
related to the ViewBackend in process of destruction. This is done by setting the `source->fd = -1` (see how below). To do this, the only public method that we can invoke in the Wayland server API is the `wl_client_destroy()`:

```cpp
WL_EXPORT void
wl_client_destroy(struct wl_client *client)
{
        uint32_t serial = 0;

        wl_priv_signal_emit(&client->destroy_signal, client);

        wl_client_flush(client);
        wl_map_for_each(&client->objects, destroy_resource, &serial);
        wl_map_release(&client->objects);
        wl_event_source_remove(client->source); <<<<<<<<<<<
        close(wl_connection_destroy(client->connection));
        wl_list_remove(&client->link);
        wl_list_remove(&client->resource_created_signal.listener_list);
        free(client);
}
```

```cpp
wl_event_source_remove(struct wl_event_source *source)
    ...
    if (source->fd >= 0) {
      epoll_ctl(loop->epoll_fd, EPOLL_CTL_DEL, source->fd, NULL);
      close(source->fd);
      source->fd = -1;  <<<<<<<<<<<<<
    }
```

## How the `wl_event_source` are dispatched and how we can avoid a source to be dispatched:

The WS epoll events are added into the ServerSource. Those events come from all the `ws_clients` (0 or more ViewBackends; each one with its own `wl_client`).

Every time that the GSource `dispatch` stage is reached, a `wl_event_loop_dispatch()` is called to dispatch the Wayland events loop for the Wayland display associated to the source:

in `ws.cpp`:

```cpp
GSourceFuncs ServerSource::s_sourceFuncs = {
    ...
    // dispatch
    [](GSource* base, GSourceFunc, gpointer) -> gboolean
    {
        auto& source = *reinterpret_cast<ServerSource*>(base);

        if (source.pfd.revents & G_IO_IN) {
            struct wl_event_loop* eventLoop =
            wl_display_get_event_loop(source.display);
            wl_event_loop_dispatch(eventLoop, 0);
            wl_display_flush_clients(source.display); <<<
        }

        if (source.pfd.revents & (G_IO_ERR | G_IO_HUP))
            return FALSE;

        source.pfd.revents = 0;
        return TRUE;
    },
```

This `wl_event_loop_dispatch()` dispatches all the `wl_event_source` attached to this `wl_event_loop` (no matters from what wl_client come from). Only the ones with `fd == -1` are skipped (**!!!**):

in  `wayland`:

```cpp
wl_event_loop_dispatch()
    ...
    for (i = 0; i < count; i++) {
        source = ep[i].data.ptr;
        if (source->fd != -1)  <<<<<<<<<<<<
            source->interface->dispatch(source, &ep[i]);
...
    }
```

The `dispatch()` invokes the `wl_client_connection_data()` what possibly could got a Wayland error (`WL_EVENT_ERROR | WL_EVENT_HANGUP`) (for example, if the peer is being closed and the fd is gone) (_this is important_). In this situation the `wl_client_destroy()` will be invoked to effectively destroy the client:

```cpp
static int
wl_client_connection_data(int fd, uint32_t mask, void *data)
{
        struct wl_client *client = data;
        ...
        if (mask & (WL_EVENT_ERROR | WL_EVENT_HANGUP)) {  <<<<<<<<<<<<
                wl_client_destroy(client); <<<<<<<<<<<<<<<
                return 1;
        }
```

This `wl_client_destroy()` can lead in a crash due to a double-free like
the one previously commented in [127#discussion_r583508043](https://github.com/Igalia/WPEBackend-fdo/pull/127#discussion_r583508043)

The safeguarded destruction of the `wl_client` in the `ViewBackend::unregisterSurface()` will inhibit the `wl_event_loop_dispatch()` loop dispatch events for the sources being unregistered.

## Explanation about how this patch affect to the workflows where the crashes were found:

### The original crash 

[127#discussion_r583508043](https://github.com/Igalia/WPEBackend-fdo/pull/127#discussion_r583508043)

1. The wc_client associated to that surface WAS NOT YET destroyed by an error in the channel (in some call to `wl_client_connection_data()`)
1. The patch will force the wl_client destruction in the `Instance::unregisterViewBackend()`
1. The associated `wl_event_source` WILL be detached from the `wl_event_loop` because the `wl_client` now destroyed
  and the `wl_event_loop_dispatch`  will skip that source because the  `source.fd=-1`
1. The `wl_client_connection_data()` will not be invoked so no a second  `wl_client_destroy()` call will called

### The one introduced by https://github.com/Igalia/WPEBackend-fdo/pull/127/commits/d086b69397f529ef175ce89909fe443e4f1393dd

[127#discussion_r578492400](https://github.com/Igalia/WPEBackend-fdo/pull/127#discussion_r578492400)

1. WebProcess (as ws-client) sends a IPC-unregister-surface messages
1. The UI-process catch the unregister message.
1. The wc_client associated to that surface WAS already destroyed by an error in the channel (in some call to `wl_client_connection_data()`)
1. The wl_client_destroy listener in ViewBackend captures the wl_client destruction and sets the client.object = NULL
1. This new patch will IGNORE the destruction of the wl_client because  the client.object is NULL
1. The `wl_event_source` IS already detached from the `wl_event_loop` because the `wl_client` is already destroyed
1. The `wl_event_loop_dispatch`  will skip that source because the  `source.fd=-1`
