### PR TITLE
Backport to wpebackend-fdo 1.8: Safeguard access to destroyed wl_client

### DIFF
--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -127,19 +127,19 @@ void ViewBackend::registerSurface(uint32_t surfaceId)
 {
     m_surfaceId = surfaceId;
     m_client = WS::Instance::singleton().registerViewBackend(m_surfaceId, *this);
-    this->m_destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
+ 
+    struct wl_client_destroy_listener *listener = new wl_client_destroy_listener {this, };
+    listener->destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
     {
-        ViewBackend *viewBackend;
-        viewBackend = wl_container_of(listener, viewBackend, m_destroyClientListener);
+        struct wl_client_destroy_listener *container;
+        container = wl_container_of(listener, container, destroyClientListener);
 
         struct wl_client* client = (struct wl_client*) data;
-        g_debug("ViewBackend <%p>: wl_client <%p> destroy notification for fd %d", viewBackend, data, wl_client_get_fd(client));
-        viewBackend->m_client = NULL;
+        container->backend->m_client = NULL;
+        delete container;  // Release the wl_client_destroy_listener instance since this is not longer needed.
     };
     wl_client_add_destroy_listener(m_client,
-                                   &this->m_destroyClientListener);
-
-
+                                   &listener->destroyClientListener);
 }
 
 void ViewBackend::unregisterSurface(uint32_t surfaceId)

--- a/src/view-backend-exportable-private.cpp
+++ b/src/view-backend-exportable-private.cpp
@@ -139,6 +139,8 @@ void ViewBackend::unregisterSurface(uint32_t surfaceId)
 
     clearFrameCallbacks();
 
+    g_clear_pointer(&m_client.object, wl_client_destroy);
+
     WS::Instance::singleton().unregisterViewBackend(m_surfaceId);
     m_surfaceId = 0;
 }

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -101,6 +101,7 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
+    struct wl_listener m_destroyClientListener;
 };
 
 struct wpe_view_backend_exportable_fdo {

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -101,7 +101,11 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
-    struct wl_listener m_destroyClientListener;
+};
+
+struct wl_client_destroy_listener {
+    ViewBackend* backend;
+    struct wl_listener destroyClientListener;
 };
 
 struct wpe_view_backend_exportable_fdo {

--- a/src/view-backend-exportable-private.h
+++ b/src/view-backend-exportable-private.h
@@ -92,7 +92,12 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_surfaceId { 0 };
-    struct wl_client* m_client { nullptr };
+    struct Client {
+        struct wl_client* object { nullptr };
+        struct wl_listener destroyListener;
+
+        static void destroyNotify(struct wl_listener*, void*);
+    } m_client;
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
@@ -101,11 +106,6 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
-};
-
-struct wl_client_destroy_listener {
-    ViewBackend* backend;
-    struct wl_listener destroyClientListener;
 };
 
 struct wpe_view_backend_exportable_fdo {

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -516,7 +516,6 @@ void Instance::unregisterViewBackend(uint32_t surfaceId)
     auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->exportableClient = nullptr;
-        wl_client_destroy(it->second->client);
         m_viewBackendMap.erase(it);
     }
 }

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -516,6 +516,7 @@ void Instance::unregisterViewBackend(uint32_t surfaceId)
     auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->exportableClient = nullptr;
+        wl_client_destroy(it->second->client);
         m_viewBackendMap.erase(it);
     }
 }


### PR DESCRIPTION

**Motivation:**

Backport of the following to Pull Requests from master to the wpebackend-fdo-1.8 branch: https://github.com/Igalia/WPEBackend-fdo/pull/127; https://github.com/Igalia/WPEBackend-fdo/pull/140

These 2 Pull Requests fix several crashes related to the ViewBackend destruction. Both crashes are vastly documented in the backlog of each Pull Request (PR).


**Detailed list of backported commits:** d688cd2558807c1ed15d67e5b0ecfad52a2bf90b;  d7577891d505a3fb037ec14e54568fe59e310941; 9e7dfbe7cbca8bc59c81d1e6421a527a87796880; 9a0e6cb62bfae44ef3496d950899ecb34ddd24a5; 87f032c8d34fe18060743ab60a6ca7f64e07f751