### PR TITLE
Include <wpe/wpe.h> from the top-level API headers

### DIFF
--- a/include/wpe/fdo-egl.h
+++ b/include/wpe/fdo-egl.h
@@ -30,6 +30,8 @@
 #ifndef __wpe_fdo_egl_h__
 #define __wpe_fdo_egl_h__
 
+#include <wpe/wpe.h>
+
 #define __WPE_FDO_EGL_H_INSIDE__
 
 #include "exported-buffer-shm.h"

--- a/include/wpe/fdo.h
+++ b/include/wpe/fdo.h
@@ -30,6 +30,8 @@
 #ifndef __wpe_fdo_h__
 #define __wpe_fdo_h__
 
+#include <wpe/wpe.h>
+
 #define __WPE_FDO_H_INSIDE__
 
 #include "version.h"


### PR DESCRIPTION
Make `<wpe/fdo.h>` and `<wpe/fdo-egl.h>` include `<wpe/wpe.h>`, which is after all a dependency. Code that relied on the latter being automatically pulled in stopped building after #132, so modifying the top-level headers this way keeps the existing expectation.

Fixes #141