### PR TITLE
ws: Accumulate surface frame callbacks until commit

### DIFF
--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -63,7 +63,6 @@ public:
 
     void initialize();
     int clientFd();
-    void frameCallback(struct wl_resource* callbackResource) override;
     void exportBufferResource(struct wl_resource* bufferResource) override;
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
     void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
@@ -72,21 +71,10 @@ public:
     void releaseBuffer(struct wl_resource* buffer_resource);
 
 private:
-    struct FrameCallbackResource {
-        struct wl_resource* resource;
-
-        struct wl_list link;
-        struct wl_listener destroyListener;
-
-        static void destroyNotify(struct wl_listener*, void*);
-    };
-
     void didReceiveMessage(uint32_t messageId, uint32_t messageBody) override;
 
     void registerSurface(uint32_t);
     void unregisterSurface(uint32_t);
-
-    void clearFrameCallbacks();
 
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
@@ -98,8 +86,6 @@ private:
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
-
-    struct wl_list m_frameCallbacks;
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };

--- a/src/ws.h
+++ b/src/ws.h
@@ -41,7 +41,6 @@ namespace WS {
 struct APIClient {
     virtual ~APIClient() = default;
 
-    virtual void frameCallback(struct wl_resource*) = 0;
     virtual void exportBufferResource(struct wl_resource*) = 0;
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
@@ -52,6 +51,18 @@ struct Surface {
     explicit Surface(struct wl_resource* surfaceResource):
         resource {surfaceResource}
     {
+        wl_list_init(&m_pendingFrameCallbacks);
+        wl_list_init(&m_currentFrameCallbacks);
+    }
+
+    ~Surface()
+    {
+        struct wl_resource* resource;
+        struct wl_resource* tmp;
+        wl_resource_for_each_safe(resource, tmp, &m_pendingFrameCallbacks)
+            wl_resource_destroy(resource);
+        wl_resource_for_each_safe(resource, tmp, &m_currentFrameCallbacks)
+            wl_resource_destroy(resource);
     }
 
     struct wl_resource* resource;
@@ -61,6 +72,31 @@ struct Surface {
     struct wl_resource* bufferResource { nullptr };
     const struct linux_dmabuf_buffer* dmabufBuffer { nullptr };
     struct wl_shm_buffer* shmBuffer { nullptr };
+
+    void commit()
+    {
+        wl_list_insert_list(&m_currentFrameCallbacks, &m_pendingFrameCallbacks);
+        wl_list_init(&m_pendingFrameCallbacks);
+    }
+
+    void addFrameCallback(struct wl_resource* resource)
+    {
+        wl_list_insert(m_pendingFrameCallbacks.prev, wl_resource_get_link(resource));
+    }
+
+    void dispatchFrameCallbacks()
+    {
+        struct wl_resource* resource;
+        struct wl_resource* tmp;
+        wl_resource_for_each_safe(resource, tmp, &m_currentFrameCallbacks) {
+            wl_callback_send_done(resource, 0);
+            wl_resource_destroy(resource);
+        }
+    }
+
+private:
+    struct wl_list m_pendingFrameCallbacks;
+    struct wl_list m_currentFrameCallbacks;
 };
 
 class Instance {
@@ -95,6 +131,7 @@ public:
     void registerSurface(uint32_t, Surface*);
     struct wl_client* registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
+    void dispatchFrameCallbacks(uint32_t);
 
     using VideoPlaneDisplayDmaBufCallback = std::function<void(struct wpe_video_plane_display_dmabuf_export*, uint32_t, int, int32_t, int32_t, int32_t, int32_t, uint32_t)>;
     using VideoPlaneDisplayDmaBufEndOfStreamCallback = std::function<void(uint32_t)>;


### PR DESCRIPTION
Move code around to accumulate surface frame callback additions until changes are comitted to the surface, as intended according to the base Wayland protocol specification.

As a bonus, remove the auxiliar `ViewBackend::FrameCallbackResource` by passing a destruction callback to `wl_resource_set_implementation()` and using the internal `wl_resource` list link.