### PR TITLE
Stop crashing!

### DIFF
--- a/src/extensions/audio.cpp
+++ b/src/extensions/audio.cpp
@@ -159,6 +159,9 @@ public:
         wl_display_roundtrip_queue(display, eventQueue);
         wl_registry_destroy(registry);
 
+        if (!m_wl.audio)
+            g_error("Failed to bind wpe_audio");
+
         wl_event_queue_destroy(eventQueue);
     }
 

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -159,6 +159,9 @@ public:
         wl_display_roundtrip_queue(display, eventQueue);
         wl_registry_destroy(registry);
 
+        if (!m_wl.videoPlaneDisplayDmaBuf)
+            g_error("Failed to bind wpe_video_plane_display_dmabuf");
+
         wl_event_queue_destroy(eventQueue);
     }
 

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -139,8 +139,6 @@ void ViewBackend::unregisterSurface(uint32_t surfaceId)
 
     clearFrameCallbacks();
 
-    g_clear_pointer(&m_client.object, wl_client_destroy);
-
     WS::Instance::singleton().unregisterViewBackend(m_surfaceId);
     m_surfaceId = 0;
 }

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -91,10 +91,12 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_surfaceId { 0 };
+    struct Client {
+        struct wl_client* object { nullptr };
+        struct wl_listener destroyListener;
 
-    static void clientDestroyNotify(struct wl_listener*, void*);
-    struct wl_listener m_clientDestroy { {}, clientDestroyNotify };
-    struct wl_client* m_client { nullptr };
+        static void destroyNotify(struct wl_listener*, void*);
+    } m_client;
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;

--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -126,6 +126,9 @@ BaseBackend::BaseBackend(int hostFD)
     wl_display_roundtrip(m_wl.display);
     wl_registry_destroy(registry);
 
+    if (!m_wl.wpeBridge)
+        g_error("Failed to bind wpe_bridge");
+
     wpe_bridge_add_listener(m_wl.wpeBridge, &s_bridgeListener, this);
     wpe_bridge_initialize(m_wl.wpeBridge);
     wl_display_roundtrip(m_wl.display);
@@ -203,6 +206,11 @@ void BaseTarget::initialize(BaseBackend& backend)
     wl_registry_add_listener(registry, &s_registryListener, this);
     wl_display_roundtrip_queue(display, m_wl.eventQueue);
     wl_registry_destroy(registry);
+
+    if (!m_wl.compositor)
+        g_error("Failed to bind wl_compositor");
+    if (!m_wl.wpeBridge)
+        g_error("Failed to bind wpe_bridge");
 
     m_wl.surface = wl_compositor_create_surface(m_wl.compositor);
     wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(m_wl.surface), m_wl.eventQueue);

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -532,6 +532,7 @@ void Instance::unregisterViewBackend(uint32_t surfaceId)
     auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
+        wl_client_destroy(it->second->client);
         m_viewBackendMap.erase(it);
     }
 }

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -532,7 +532,6 @@ void Instance::unregisterViewBackend(uint32_t surfaceId)
     auto it = m_viewBackendMap.find(surfaceId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
-        wl_client_destroy(it->second->client);
         m_viewBackendMap.erase(it);
     }
 }


### PR DESCRIPTION
Currently, we crash if process-swapping back to a process that
previously had an accelerated surface. The crash occurs because the web
process is not prepared for its connection to the UI process to fail.
The UI process recently began closing its connection to the web process
too soon. It incorrectly assumed that it's safe to close the connection
when a surface is deregistered, which corresponds to the destruction of
a WS::BaseTarget in the web process. But in fact, the connection to the
web process needs to be kept open until the WS::BaseBackend is destroyed
in the web process. Each BaseBackend may have more than one BaseTarget.
A new BaseTarget is created when displaying a new page.

Reverting this sequence of commits avoids this misunderstanding and fixes #145.

Finally, I add some asserts to ensure we crash ASAP if globals are not properly bound in the future.