### PR TITLE
Add some checks to ensure we properly bind server globals

### DIFF
--- a/src/extensions/audio.cpp
+++ b/src/extensions/audio.cpp
@@ -159,6 +159,9 @@ public:
         wl_display_roundtrip_queue(display, eventQueue);
         wl_registry_destroy(registry);
 
+        if (!m_wl.audio)
+            g_error("Failed to bind wpe_audio");
+
         wl_event_queue_destroy(eventQueue);
     }
 

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -159,6 +159,9 @@ public:
         wl_display_roundtrip_queue(display, eventQueue);
         wl_registry_destroy(registry);
 
+        if (!m_wl.videoPlaneDisplayDmaBuf)
+            g_error("Failed to bind wpe_video_plane_display_dmabuf");
+
         wl_event_queue_destroy(eventQueue);
     }
 

--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -126,6 +126,9 @@ BaseBackend::BaseBackend(int hostFD)
     wl_display_roundtrip(m_wl.display);
     wl_registry_destroy(registry);
 
+    if (!m_wl.wpeBridge)
+        g_error("Failed to bind wpe_bridge");
+
     wpe_bridge_add_listener(m_wl.wpeBridge, &s_bridgeListener, this);
     wpe_bridge_initialize(m_wl.wpeBridge);
     wl_display_roundtrip(m_wl.display);
@@ -203,6 +206,11 @@ void BaseTarget::initialize(BaseBackend& backend)
     wl_registry_add_listener(registry, &s_registryListener, this);
     wl_display_roundtrip_queue(display, m_wl.eventQueue);
     wl_registry_destroy(registry);
+
+    if (!m_wl.compositor)
+        g_error("Failed to bind wl_compositor");
+    if (!m_wl.wpeBridge)
+        g_error("Failed to bind wpe_bridge");
 
     m_wl.surface = wl_compositor_create_surface(m_wl.compositor);
     wl_proxy_set_queue(reinterpret_cast<struct wl_proxy*>(m_wl.surface), m_wl.eventQueue);


### PR DESCRIPTION
If we fail to bind any global objects, we are going to crash. Let's do
that as nicely as possible using g_error(), rather than dereferencing
null pointers later on.

Suggested by #145