### PR TITLE
A couple of wpe_bridge related cleanups

### DIFF
--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -41,7 +41,7 @@ ViewBackend::ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* ba
 
 ViewBackend::~ViewBackend()
 {
-    unregisterSurface(m_surfaceId);
+    unregisterSurface(m_bridgeId);
     if (m_clientFd != -1)
         close(m_clientFd);
 }
@@ -131,29 +131,28 @@ void ViewBackend::clientDestroyNotify(struct wl_listener* listener, void*)
     ViewBackend* self = wl_container_of(listener, self, m_clientDestroy);
 
     self->clearFrameCallbacks();
-    WS::Instance::singleton().unregisterViewBackend(self->m_surfaceId);
+    WS::Instance::singleton().unregisterViewBackend(self->m_bridgeId);
     self->m_client = nullptr;
-    self->m_surfaceId = 0;
+    self->m_bridgeId = 0;
 
     wl_list_remove(&self->m_clientDestroy.link);
 }
 
-void ViewBackend::registerSurface(uint32_t surfaceId)
+void ViewBackend::registerSurface(uint32_t bridgeId)
 {
-
-    if (m_surfaceId == surfaceId)
+    if (m_bridgeId == bridgeId)
         return;
 
-    unregisterSurface(m_surfaceId);
+    unregisterSurface(m_bridgeId);
 
-    m_surfaceId = surfaceId;
-    m_client = WS::Instance::singleton().registerViewBackend(m_surfaceId, *this);
+    m_bridgeId = bridgeId;
+    m_client = WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
     wl_client_add_destroy_listener(m_client, &m_clientDestroy);
 }
 
-void ViewBackend::unregisterSurface(uint32_t surfaceId)
+void ViewBackend::unregisterSurface(uint32_t bridgeId)
 {
-    if (!surfaceId || m_surfaceId != surfaceId)
+    if (!bridgeId || m_bridgeId != bridgeId)
         return;
 
     // If the surfaceId is valid, we cannot have an invalid wl_client.
@@ -165,7 +164,7 @@ void ViewBackend::unregisterSurface(uint32_t surfaceId)
 
     // After destroying the client, none of these can be valid.
     g_assert(m_client == nullptr);
-    g_assert(m_surfaceId == 0);
+    g_assert(m_bridgeId == 0);
 }
 
 void ViewBackend::didReceiveMessage(uint32_t messageId, uint32_t messageBody)

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -90,7 +90,7 @@ private:
 
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
-    uint32_t m_surfaceId { 0 };
+    uint32_t m_bridgeId { 0 };
 
     static void clientDestroyNotify(struct wl_listener*, void*);
     struct wl_listener m_clientDestroy { {}, clientDestroyNotify };

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -144,9 +144,7 @@ static const struct wl_compositor_interface s_compositorInterface = {
             return;
         }
 
-        auto* surface = new Surface;
-        surface->client = client;
-        surface->id = id;
+        auto* surface = new Surface {surfaceResource};
         wl_resource_set_implementation(surfaceResource, &s_surfaceInterface, surface,
             [](struct wl_resource* resource)
             {
@@ -524,7 +522,7 @@ struct wl_client* Instance::registerViewBackend(uint32_t surfaceId, APIClient& a
         g_error("Instance::registerViewBackend(): " "Cannot find surface %" PRIu32 " in view backend map.", surfaceId);
 
     it->second->apiClient = &apiClient;
-    return it->second->client;
+    return wl_resource_get_client(it->second->resource);
 }
 
 void Instance::unregisterViewBackend(uint32_t surfaceId)

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -515,19 +515,19 @@ void Instance::releaseAudioPacketExport(struct wpe_audio_packet_export* packet_e
     wpe_audio_packet_export_send_release(packet_export->exportResource);
 }
 
-struct wl_client* Instance::registerViewBackend(uint32_t surfaceId, APIClient& apiClient)
+struct wl_client* Instance::registerViewBackend(uint32_t bridgeId, APIClient& apiClient)
 {
-    auto it = m_viewBackendMap.find(surfaceId);
+    auto it = m_viewBackendMap.find(bridgeId);
     if (it == m_viewBackendMap.end())
-        g_error("Instance::registerViewBackend(): " "Cannot find surface %" PRIu32 " in view backend map.", surfaceId);
+        g_error("Instance::registerViewBackend(): " "Cannot find surface with bridgeId %" PRIu32 " in view backend map.", bridgeId);
 
     it->second->apiClient = &apiClient;
     return wl_resource_get_client(it->second->resource);
 }
 
-void Instance::unregisterViewBackend(uint32_t surfaceId)
+void Instance::unregisterViewBackend(uint32_t bridgeId)
 {
-    auto it = m_viewBackendMap.find(surfaceId);
+    auto it = m_viewBackendMap.find(bridgeId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
         m_viewBackendMap.erase(it);

--- a/src/ws.h
+++ b/src/ws.h
@@ -48,10 +48,13 @@ struct APIClient {
     virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
 };
 
-struct Surface;
 struct Surface {
-    uint32_t id { 0 };
-    struct wl_client* client { nullptr };
+    explicit Surface(struct wl_resource* surfaceResource):
+        resource {surfaceResource}
+    {
+    }
+
+    struct wl_resource* resource;
 
     APIClient* apiClient { nullptr };
 

--- a/src/ws.h
+++ b/src/ws.h
@@ -128,6 +128,7 @@ private:
     struct wl_global* m_wpeBridge { nullptr };
     GSource* m_source { nullptr };
 
+    // (bridgeId -> Surface)
     std::unordered_map<uint32_t, Surface*> m_viewBackendMap;
 
     struct {


### PR DESCRIPTION
This has two commits with changes that (IMO) make the code a tad easier to follow:

* The `Surface::id` and `Surface::client` members can both be replaced by keeping around the  `wl_resource`, and query its client with `wl_resource_get_client()`; the identifier itself is never used—and if ever needed, there is `wl_resource_get_id()` which could be used.
* The `WS::Singleton::m_viewBackendMap` associated an identifier generated by the `wpe_bridge` interface with a given `Surface`, hence using “surfaceId” around is misleading and changing variables to use “bridgeId” seems more appropriate. 