### PR TITLE
Meson: Fix the build with Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.5
       - name: Python Package Cache
         uses: actions/cache@v1
         with:

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -18,6 +18,6 @@ with open(version_file, "r") as f:
     for line in f.readlines():
         m = version_re.match(line)
         if m:
-            version[m[1]] = m[2]
+            version[m.group(1)] = m.group(2)
 
 print("{}.{}.{}".format(version["MAJOR"], version["MINOR"], version["MICRO"]))


### PR DESCRIPTION
In theory we support building with Python as old as 3.5, but the CI was using 3.6. This downgrades the version used when doing test builds, and fixes an issue in the `scripts/version.py` helper script.