### PR TITLE
ws: Remove wl_client pointer that can end up dangling

### DIFF
--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -120,8 +120,6 @@ void ViewBackend::unregisterSurface(uint32_t bridgeId)
     if (!bridgeId || m_bridgeId != bridgeId)
         return;
 
-    g_clear_pointer(&m_client.object, wl_client_destroy);
-
     WS::Instance::singleton().unregisterViewBackend(m_bridgeId);
     m_bridgeId = 0;
 }

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -95,20 +95,19 @@ void ViewBackend::dispatchFrameCallbacks()
     if (G_LIKELY(m_bridgeId))
         WS::Instance::singleton().dispatchFrameCallbacks(m_bridgeId);
 
-    wl_client_flush(m_client);
     wpe_view_backend_dispatch_frame_displayed(m_backend);
 }
 
 void ViewBackend::releaseBuffer(struct wl_resource* buffer_resource)
 {
     wl_buffer_send_release(buffer_resource);
-    wl_client_flush(m_client);
+    wl_client_flush(wl_resource_get_client(buffer_resource));
 }
 
 void ViewBackend::registerSurface(uint32_t bridgeId)
 {
     m_bridgeId = bridgeId;
-    m_client = WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
+    WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
 }
 
 void ViewBackend::unregisterSurface(uint32_t bridgeId)

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -95,33 +95,20 @@ void ViewBackend::dispatchFrameCallbacks()
     if (G_LIKELY(m_bridgeId))
         WS::Instance::singleton().dispatchFrameCallbacks(m_bridgeId);
 
-    if (m_client)
-        wl_client_flush(m_client);
+    wl_client_flush(m_client);
     wpe_view_backend_dispatch_frame_displayed(m_backend);
 }
 
 void ViewBackend::releaseBuffer(struct wl_resource* buffer_resource)
 {
     wl_buffer_send_release(buffer_resource);
-    if (m_client)
-        wl_client_flush(m_client);
+    wl_client_flush(m_client);
 }
 
 void ViewBackend::registerSurface(uint32_t bridgeId)
 {
     m_bridgeId = bridgeId;
     m_client = WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
-
-    this->m_destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
-    {
-        ViewBackend *viewBackend = wl_container_of(listener, viewBackend, m_destroyClientListener);
-
-        struct wl_client* client = (struct wl_client*) data;
-        g_debug("ViewBackend <%p>: wl_client <%p> destroy notification for fd %d", viewBackend, data, wl_client_get_fd(client));
-        viewBackend->m_client = NULL;
-    };
-    wl_client_add_destroy_listener(m_client,
-                                   &this->m_destroyClientListener);
 }
 
 void ViewBackend::unregisterSurface(uint32_t bridgeId)

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -112,16 +112,16 @@ void ViewBackend::registerSurface(uint32_t bridgeId)
     m_bridgeId = bridgeId;
     m_client = WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
 
-    struct wl_client_destroy_listener *listener = new wl_client_destroy_listener {this, };
-    listener->destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
+    this->m_destroyClientListener.notify = (wl_notify_func_t) [](struct wl_listener* listener, void* data)
     {
-        struct wl_client_destroy_listener *container;
-        container = wl_container_of(listener, container, destroyClientListener);
-        container->backend->m_client = NULL;
-        delete container;  // Release the wl_client_destroy_listener instance since this is not longer needed.
+        ViewBackend *viewBackend = wl_container_of(listener, viewBackend, m_destroyClientListener);
+
+        struct wl_client* client = (struct wl_client*) data;
+        g_debug("ViewBackend <%p>: wl_client <%p> destroy notification for fd %d", viewBackend, data, wl_client_get_fd(client));
+        viewBackend->m_client = NULL;
     };
     wl_client_add_destroy_listener(m_client,
-                                   &listener->destroyClientListener);
+                                   &this->m_destroyClientListener);
 }
 
 void ViewBackend::unregisterSurface(uint32_t bridgeId)

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -79,18 +79,18 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_bridgeId { 0 };
-    struct Client {
-        struct wl_client* object { nullptr };
-        struct wl_listener destroyListener;
-
-        static void destroyNotify(struct wl_listener*, void*);
-    } m_client;
+    struct wl_client* m_client { nullptr };
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
+};
+
+struct wl_client_destroy_listener {
+    ViewBackend* backend;
+    struct wl_listener destroyClientListener;
 };
 
 struct wpe_view_backend_private {

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -86,7 +86,6 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
-    struct wl_listener m_destroyClientListener;
 };
 
 struct wpe_view_backend_private {

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -79,10 +79,12 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_bridgeId { 0 };
+    struct Client {
+        struct wl_client* object { nullptr };
+        struct wl_listener destroyListener;
 
-    static void clientDestroyNotify(struct wl_listener*, void*);
-    struct wl_listener m_clientDestroy { {}, clientDestroyNotify };
-    struct wl_client* m_client { nullptr };
+        static void destroyNotify(struct wl_listener*, void*);
+    } m_client;
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -79,7 +79,6 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_bridgeId { 0 };
-    struct wl_client* m_client { nullptr };
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -86,11 +86,7 @@ private:
 
     std::unique_ptr<FdoIPC::Connection> m_socket;
     int m_clientFd { -1 };
-};
-
-struct wl_client_destroy_listener {
-    ViewBackend* backend;
-    struct wl_listener destroyClientListener;
+    struct wl_listener m_destroyClientListener;
 };
 
 struct wpe_view_backend_private {

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -534,6 +534,7 @@ void Instance::unregisterViewBackend(uint32_t bridgeId)
     auto it = m_viewBackendMap.find(bridgeId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
+        wl_client_destroy(wl_resource_get_client(it->second->resource));
         m_viewBackendMap.erase(it);
     }
 }

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -534,7 +534,6 @@ void Instance::unregisterViewBackend(uint32_t bridgeId)
     auto it = m_viewBackendMap.find(bridgeId);
     if (it != m_viewBackendMap.end()) {
         it->second->apiClient = nullptr;
-        wl_client_destroy(wl_resource_get_client(it->second->resource));
         m_viewBackendMap.erase(it);
     }
 }

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -519,14 +519,13 @@ void Instance::releaseAudioPacketExport(struct wpe_audio_packet_export* packet_e
     wpe_audio_packet_export_send_release(packet_export->exportResource);
 }
 
-struct wl_client* Instance::registerViewBackend(uint32_t bridgeId, APIClient& apiClient)
+void Instance::registerViewBackend(uint32_t bridgeId, APIClient& apiClient)
 {
     auto it = m_viewBackendMap.find(bridgeId);
     if (it == m_viewBackendMap.end())
         g_error("Instance::registerViewBackend(): " "Cannot find surface with bridgeId %" PRIu32 " in view backend map.", bridgeId);
 
     it->second->apiClient = &apiClient;
-    return wl_resource_get_client(it->second->resource);
 }
 
 void Instance::unregisterViewBackend(uint32_t bridgeId)

--- a/src/ws.h
+++ b/src/ws.h
@@ -136,6 +136,7 @@ public:
     int createClient();
 
     void registerSurface(uint32_t, Surface*);
+    void unregisterSurface(Surface*);
     void registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
     void dispatchFrameCallbacks(uint32_t);

--- a/src/ws.h
+++ b/src/ws.h
@@ -88,10 +88,17 @@ struct Surface {
     {
         struct wl_resource* resource;
         struct wl_resource* tmp;
+        struct wl_client* client { nullptr };
+
         wl_resource_for_each_safe(resource, tmp, &m_currentFrameCallbacks) {
+            g_assert(!client || client == wl_resource_get_client(resource));
+            client = wl_resource_get_client(resource);
             wl_callback_send_done(resource, 0);
             wl_resource_destroy(resource);
         }
+
+        if (client)
+            wl_client_flush(client);
     }
 
 private:
@@ -129,7 +136,7 @@ public:
     int createClient();
 
     void registerSurface(uint32_t, Surface*);
-    struct wl_client* registerViewBackend(uint32_t, APIClient&);
+    void registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
     void dispatchFrameCallbacks(uint32_t);
 


### PR DESCRIPTION
Instead of trying to keep track of the destruction of the `wl_client` referenced by `ViewBackend::m_client`, completely remove the member variable and instead:
    
- In `ViewBackend::releaseBuffer()` use `wl_resource_get_client()` to obtain the `wl_client` from the buffer resource. Given that the buffer resource has just been used, it is guaranteed that the `wl_client` it refers to should be still valid.
    
- In `ViewBackend::dispatchFrameCallbacks()` remove the flush call, and instead do it in `WS::Surface::dispatchFrameCallbacks()`, and pick the `wl_client` from the callback resource objects, if any callback was dispatched at all. Again, if any callback was dispatched their associated `wl_client` should be still valid. Skipping the flush if no callbacks are dispatched is fine because in that case there would not be any messages  pending be sent over the wire anyway to trigger dispatching the callbacks in the client side.

This MR reverts half a dozen commits which were attempting to handle destruction of the `wl_client` gracefully, because after going in circles for a couple of weeks I think that the best approach is the one suggested in the last commit of this PR and letting libwayland take care of things for us.

Also because of the many reverts, I would review at least the last commit separately, because trying to understand the whole diff from `master` is a bit too much 📜 

----

Fixes #145

Note that this includes now also the changes from #154