### PR TITLE
Set back the ViewBackend to the previous bridge references

### DIFF
--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -119,6 +119,7 @@ void ViewBackend::unregisterSurface(uint32_t bridgeId)
     if (!bridgeId)
         return;
     WS::Instance::singleton().unregisterViewBackend(bridgeId);
+    m_bridgeId = 0;
 }
 
 void ViewBackend::didReceiveMessage(uint32_t messageId, uint32_t messageBody)

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -38,6 +38,7 @@ ViewBackend::ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* ba
 
 ViewBackend::~ViewBackend()
 {
+    fprintf(stderr,"ViewBackend::~ViewBackend: this: (%p)\n", this);
     unregisterSurface(m_bridgeId);
 
     if (m_clientFd != -1)
@@ -46,6 +47,7 @@ ViewBackend::~ViewBackend()
 
 void ViewBackend::initialize()
 {
+    fprintf(stderr,"ViewBackend::initialize: this: (%p)\n", this);
     int sockets[2];
     int ret = socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sockets);
     if (ret == -1)
@@ -92,10 +94,13 @@ void ViewBackend::exportEGLStreamProducer(struct wl_resource* bufferResource)
 
 void ViewBackend::dispatchFrameCallbacks()
 {
+    fprintf(stderr,"ViewBackend::dispatchFrameCallbacks: (1/2) this: (%p) - m_bridgeId: %" PRIu32 "\n", this, m_bridgeId);
     if (G_LIKELY(m_bridgeId))
         WS::Instance::singleton().dispatchFrameCallbacks(m_bridgeId);
 
     m_fallback_bridgeId = m_bridgeId;
+
+    fprintf(stderr,"ViewBackend::dispatchFrameCallbacks: (2/2) wpe_view_backend_dispatch_frame_displayed this: (%p) m_backend: (%p)\n", this, m_backend);
     wpe_view_backend_dispatch_frame_displayed(m_backend);
 }
 
@@ -110,16 +115,22 @@ void ViewBackend::releaseBuffer(struct wl_resource* buffer_resource)
 
 void ViewBackend::registerSurface(uint32_t bridgeId)
 {
+    fprintf(stderr,"ViewBackend::registerSurface: (1/3) this: (%p) - bridgeId: %" PRIu32 "\n", this, bridgeId);
+    fprintf(stderr,"ViewBackend::registerSurface: (2/3) this: (%p) - m_fallback_bridgeId: %" PRIu32 "\n", this, m_fallback_bridgeId);
+
     m_bridgeId = bridgeId;
+    fprintf(stderr,"ViewBackend::registerSurface: (3/3) this: (%p) - m_bridgeId: %" PRIu32 "\n", this, m_bridgeId);
     WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
 }
 
 void ViewBackend::unregisterSurface(uint32_t bridgeId)
 {
+    fprintf(stderr,"ViewBackend::unregisterSurface (1/2): this: (%p) - bridgeId: %" PRIu32 "\n", this, bridgeId);
     if (!bridgeId)
         return;
     WS::Instance::singleton().unregisterViewBackend(bridgeId);
     m_bridgeId = 0;
+    fprintf(stderr,"ViewBackend::unregisterSurface (2/2): this: (%p) - bridgeId: %" PRIu32 "\n", this, bridgeId);
 }
 
 void ViewBackend::didReceiveMessage(uint32_t messageId, uint32_t messageBody)

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -39,7 +39,7 @@ ViewBackend::ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* ba
 ViewBackend::~ViewBackend()
 {
     fprintf(stderr,"ViewBackend::~ViewBackend: this: (%p)\n", this);
-    // unregisterSurface(m_bridgeId);
+    unregisterSurface(m_bridgeId);
 
     if (m_clientFd != -1)
         close(m_clientFd);
@@ -98,7 +98,7 @@ void ViewBackend::dispatchFrameCallbacks()
     if (G_LIKELY(m_bridgeId))
         WS::Instance::singleton().dispatchFrameCallbacks(m_bridgeId);
 
-    m_fallback_bridgeId = m_bridgeId;
+    // m_fallback_bridgeId = m_bridgeId;
 
     fprintf(stderr,"ViewBackend::dispatchFrameCallbacks: (2/2) wpe_view_backend_dispatch_frame_displayed this: (%p) m_backend: (%p)\n", this, m_backend);
     wpe_view_backend_dispatch_frame_displayed(m_backend);
@@ -118,6 +118,8 @@ void ViewBackend::registerSurface(uint32_t bridgeId)
     fprintf(stderr,"ViewBackend::registerSurface: (1/3) this: (%p) - bridgeId: %" PRIu32 "\n", this, bridgeId);
     fprintf(stderr,"ViewBackend::registerSurface: (2/3) this: (%p) - m_fallback_bridgeId: %" PRIu32 "\n", this, m_fallback_bridgeId);
 
+    if (G_LIKELY(m_bridgeId))
+        WS::Instance::singleton().enableViewBackend(m_bridgeId, false);
     m_bridgeId = bridgeId;
     fprintf(stderr,"ViewBackend::registerSurface: (3/3) this: (%p) - m_bridgeId: %" PRIu32 "\n", this, m_bridgeId);
     WS::Instance::singleton().registerViewBackend(m_bridgeId, *this);
@@ -129,7 +131,7 @@ void ViewBackend::unregisterSurface(uint32_t bridgeId)
     if (!bridgeId)
         return;
     WS::Instance::singleton().unregisterViewBackend(bridgeId);
-    m_bridgeId = 0;
+    // m_bridgeId = 0;
     fprintf(stderr,"ViewBackend::unregisterSurface (2/2): this: (%p) - bridgeId: %" PRIu32 "\n", this, bridgeId);
 }
 

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -95,11 +95,15 @@ void ViewBackend::dispatchFrameCallbacks()
     if (G_LIKELY(m_bridgeId))
         WS::Instance::singleton().dispatchFrameCallbacks(m_bridgeId);
 
+    m_fallback_bridgeId = m_bridgeId;
     wpe_view_backend_dispatch_frame_displayed(m_backend);
 }
 
 void ViewBackend::releaseBuffer(struct wl_resource* buffer_resource)
 {
+    if (G_UNLIKELY(m_bridgeId == 0))
+        return;
+
     wl_buffer_send_release(buffer_resource);
     wl_client_flush(wl_resource_get_client(buffer_resource));
 }
@@ -112,11 +116,9 @@ void ViewBackend::registerSurface(uint32_t bridgeId)
 
 void ViewBackend::unregisterSurface(uint32_t bridgeId)
 {
-    if (!bridgeId || m_bridgeId != bridgeId)
+    if (!bridgeId)
         return;
-
-    WS::Instance::singleton().unregisterViewBackend(m_bridgeId);
-    m_bridgeId = 0;
+    WS::Instance::singleton().unregisterViewBackend(bridgeId);
 }
 
 void ViewBackend::didReceiveMessage(uint32_t messageId, uint32_t messageBody)

--- a/src/view-backend-private.cpp
+++ b/src/view-backend-private.cpp
@@ -39,7 +39,7 @@ ViewBackend::ViewBackend(ClientBundle* clientBundle, struct wpe_view_backend* ba
 ViewBackend::~ViewBackend()
 {
     fprintf(stderr,"ViewBackend::~ViewBackend: this: (%p)\n", this);
-    unregisterSurface(m_bridgeId);
+    // unregisterSurface(m_bridgeId);
 
     if (m_clientFd != -1)
         close(m_clientFd);

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -80,8 +80,13 @@ public:
      */
     void clientGone(uint32_t id) override
     {
-        if (id >= m_bridgeId)
+        fprintf(stderr,"ViewBackend::clientGone (m_fallback_bridgeId: %d)\n", m_fallback_bridgeId);
+        fprintf(stderr,"ViewBackend::clientGone (id: %" PRIu32 " >= m_bridgeId: %" PRIu32 ")\n", id, m_bridgeId);
+        if (id >= m_bridgeId) {
+            fprintf(stderr,"ViewBackend::clientGone TRUE\n");
             m_bridgeId = m_fallback_bridgeId;
+        }
+        fprintf(stderr,"ViewBackend::clientGone (m_bridgeId: %d, m_clientFd: %d)\n", m_bridgeId, m_clientFd);
     }
 
     void dispatchFrameCallbacks();

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -67,6 +67,23 @@ public:
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
     void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
     void exportEGLStreamProducer(struct wl_resource*) override;
+
+    /** Set back the ViewBackend to the previous bridge references
+     *
+     * Falling back to the previous bridge Id because the current Surface is
+     * gone. This action prevents inconsistencies by keeping the ViewBackend in
+     * a consistent state pointing to a still valid bridge reference.
+     *
+     * An example of a scenario that could generate this kind of inconsistency
+     * is a failed load request due to content filter policies. In that case,
+     * the client gone situation is reached because
+     */
+    void clientGone(uint32_t id) override
+    {
+        if (id >= m_bridgeId)
+            m_bridgeId = m_fallback_bridgeId;
+    }
+
     void dispatchFrameCallbacks();
     void releaseBuffer(struct wl_resource* buffer_resource);
 
@@ -79,6 +96,7 @@ private:
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
     uint32_t m_bridgeId { 0 };
+    uint32_t m_fallback_bridgeId { 0 };
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -85,8 +85,15 @@ public:
         if (id >= m_bridgeId) {
             fprintf(stderr,"ViewBackend::clientGone TRUE\n");
             m_bridgeId = m_fallback_bridgeId;
+            WS::Instance::singleton().enableViewBackend(m_bridgeId, true);
         }
         fprintf(stderr,"ViewBackend::clientGone (m_bridgeId: %d, m_clientFd: %d)\n", m_bridgeId, m_clientFd);
+    }
+
+    void setLastValidBridgeId(uint32_t id) override
+    {
+        fprintf(stderr,"ViewBackend::setLastValidBridgeId (id: %d))\n", id);
+        m_fallback_bridgeId = id;
     }
 
     void dispatchFrameCallbacks();

--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -119,6 +119,7 @@ GSourceFuncs TargetSource::s_sourceFuncs = {
 
 BaseBackend::BaseBackend(int hostFD)
 {
+    fprintf(stderr,"ws-client: BaseBackend::BaseBackend(hostFD: %d)\n",hostFD);
     m_wl.display = wl_display_connect_to_fd(hostFD);
 
     struct wl_registry* registry = wl_display_get_registry(m_wl.display);
@@ -136,6 +137,7 @@ BaseBackend::BaseBackend(int hostFD)
 
 BaseBackend::~BaseBackend()
 {
+    fprintf(stderr,"ws-client: BaseBackend::~BaseBackend()\n");
     g_clear_pointer(&m_wl.wpeBridge, wpe_bridge_destroy);
     g_clear_pointer(&m_wl.display, wl_display_disconnect);
 }
@@ -157,6 +159,7 @@ const struct wpe_bridge_listener BaseBackend::s_bridgeListener = {
     // implementation_info
     [](void* data, struct wpe_bridge*, uint32_t implementationType)
     {
+        fprintf(stderr,"wpe_bridge_listener::implementationType (1/2)\n");
         auto& backend = *reinterpret_cast<BaseBackend*>(data);
         switch (implementationType) {
         case WPE_BRIDGE_CLIENT_IMPLEMENTATION_TYPE_WAYLAND:
@@ -165,15 +168,19 @@ const struct wpe_bridge_listener BaseBackend::s_bridgeListener = {
         default:
             break;
         }
+        fprintf(stderr,"wpe_bridge_listener::implementationType (2/2)\n");
     },
     // connected
-    [](void* data, struct wpe_bridge*, uint32_t) { },
+    [](void* data, struct wpe_bridge*, uint32_t) {
+        fprintf(stderr,"ws-client: BaseBackend::s_bridgeListener.connected \n");
+    },
 };
 
 
 BaseTarget::BaseTarget(int hostFD, Impl& impl)
     : m_impl(impl)
 {
+    fprintf(stderr,"ws-client: BaseTarget::BaseTarget(hostFD: %d) \n", hostFD);
     m_glib.socket = FdoIPC::Connection::create(hostFD);
 }
 
@@ -274,6 +281,7 @@ const struct wpe_bridge_listener BaseTarget::s_bridgeListener = {
     // connected
     [](void* data, struct wpe_bridge*, uint32_t id)
     {
+        fprintf(stderr,"ws-client: BaseTarget::s_bridgeListener.connected \n");
         static_cast<BaseTarget*>(data)->bridgeConnected(id);
     },
 };

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -569,6 +569,7 @@ void Instance::unregisterViewBackend(uint32_t bridgeId)
     auto it = m_viewBackendMap.find(bridgeId);
     if (it != m_viewBackendMap.end()) {
         fprintf(stderr,"Instance::unregisterViewBackend: (2/2) erase surface (%p) - bridgeId: %" PRIu32 "\n", this, bridgeId);
+        it->second->apiClient->clientGone(bridgeId);
         it->second->apiClient = nullptr;
         it->second->disabled = true;
     }

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -545,8 +545,11 @@ void Instance::unregisterSurface(Surface* surface)
         [surface](const std::pair<uint32_t, Surface*>& value) -> bool {
             return value.second == surface;
         });
-    if (it != m_viewBackendMap.end())
+    if (it != m_viewBackendMap.end()) {
+        if (surface->apiClient)
+            surface->apiClient->clientGone(it->first);
         m_viewBackendMap.erase(it);
+    }
 }
 
 void Instance::dispatchFrameCallbacks(uint32_t bridgeId)

--- a/src/ws.h
+++ b/src/ws.h
@@ -52,12 +52,14 @@ struct Surface {
     explicit Surface(struct wl_resource* surfaceResource):
         resource {surfaceResource}
     {
+        fprintf(stderr,"Surface created \n");
         wl_list_init(&m_pendingFrameCallbacks);
         wl_list_init(&m_currentFrameCallbacks);
     }
 
     ~Surface()
     {
+        fprintf(stderr,"~Surface (this: %p)\n", this);
         struct wl_resource* resource;
         struct wl_resource* tmp;
         wl_resource_for_each_safe(resource, tmp, &m_pendingFrameCallbacks)
@@ -82,7 +84,9 @@ struct Surface {
 
     void addFrameCallback(struct wl_resource* resource)
     {
+        fprintf(stderr,"addFrameCallback (start): resource: %p - &resource: %p\n", resource, &resource);
         wl_list_insert(m_pendingFrameCallbacks.prev, wl_resource_get_link(resource));
+        fprintf(stderr,"addFrameCallback (end): resource: %p - &resource: %p\n", resource, &resource);
     }
 
     void dispatchFrameCallbacks()
@@ -91,6 +95,7 @@ struct Surface {
         struct wl_resource* tmp;
         struct wl_client* client { nullptr };
 
+        fprintf(stderr,"Surface::dispatchFrameCallbacks (this: %p)\n", this);
         wl_resource_for_each_safe(resource, tmp, &m_currentFrameCallbacks) {
             g_assert(!client || client == wl_resource_get_client(resource));
             client = wl_resource_get_client(resource);

--- a/src/ws.h
+++ b/src/ws.h
@@ -45,6 +45,7 @@ struct APIClient {
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
     virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
+    virtual void clientGone(uint32_t) {};
 };
 
 struct Surface {
@@ -134,6 +135,7 @@ public:
     Impl& impl() { return *m_impl; }
 
     int createClient();
+    void clientGone(uint32_t);
 
     void registerSurface(uint32_t, Surface*);
     void unregisterSurface(Surface*);

--- a/src/ws.h
+++ b/src/ws.h
@@ -46,6 +46,7 @@ struct APIClient {
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
     virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
     virtual void clientGone(uint32_t) {};
+    virtual void setLastValidBridgeId(uint32_t) {};
 };
 
 struct Surface {
@@ -71,6 +72,9 @@ struct Surface {
     struct wl_resource* resource;
 
     APIClient* apiClient { nullptr };
+
+    bool disabled { false };
+    uint32_t id { 0 };
 
     struct wl_resource* bufferResource { nullptr };
     const struct linux_dmabuf_buffer* dmabufBuffer { nullptr };
@@ -104,7 +108,7 @@ struct Surface {
         }
 
         if (client)
-            wl_client_flush(client);
+            wl_client_flush(client);	
     }
 
 private:
@@ -144,6 +148,7 @@ public:
 
     void registerSurface(uint32_t, Surface*);
     void unregisterSurface(Surface*);
+    void enableViewBackend(uint32_t, bool);
     void registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
     void dispatchFrameCallbacks(uint32_t);


### PR DESCRIPTION
Falling back to the previous bridge Id because the current Surface is gone. This action prevents inconsistencies by keeping the ViewBackend in a consistent state pointing to a still valid bridge reference.

An example of a scenario that could generate this kind of inconsistency is a failed load request due to content filter policies. In that case, the client gone situation is reached because

Co-authored-by: Adrian Perez de Castro <aperez@igalia.com>
Acked-by: Adrian Perez de Castro <aperez@igalia.com>
Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>