### PR TITLE
Partially revert a4eb79d, video-plane and audio can be NULL

### DIFF
--- a/src/extensions/audio.cpp
+++ b/src/extensions/audio.cpp
@@ -159,9 +159,6 @@ public:
         wl_display_roundtrip_queue(display, eventQueue);
         wl_registry_destroy(registry);
 
-        if (!m_wl.audio)
-            g_error("Failed to bind wpe_audio");
-
         wl_event_queue_destroy(eventQueue);
     }
 

--- a/src/extensions/video-plane-display-dmabuf.cpp
+++ b/src/extensions/video-plane-display-dmabuf.cpp
@@ -159,9 +159,6 @@ public:
         wl_display_roundtrip_queue(display, eventQueue);
         wl_registry_destroy(registry);
 
-        if (!m_wl.videoPlaneDisplayDmaBuf)
-            g_error("Failed to bind wpe_video_plane_display_dmabuf");
-
         wl_event_queue_destroy(eventQueue);
     }
 


### PR DESCRIPTION
Remove wrong `NULL` checks for variables which are actually allowed to be `NULL` during normal operation.

The global objects for the `wpe_audio` and `wpe_video_plane_display_dmabuf` interfaces are created dynamically when a receiver is registered for them, which means at the time the nested compositor client is connected they may be `NULL`.