### PR TITLE
Keep list of bridgeIds associated with each ViewBackend

### DIFF
--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -30,6 +30,7 @@
 
 #include <gio/gio.h>
 #include <wpe/wpe.h>
+#include <vector>
 
 class ViewBackend;
 
@@ -78,7 +79,7 @@ private:
 
     static gboolean s_socketCallback(GSocket*, GIOCondition, gpointer);
 
-    uint32_t m_bridgeId { 0 };
+    std::vector<uint32_t> m_bridgeIds;
 
     ClientBundle* m_clientBundle;
     struct wpe_view_backend* m_backend;

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -68,6 +68,12 @@ public:
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
     void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
     void exportEGLStreamProducer(struct wl_resource*) override;
+
+    void bridgeConnectionLost(uint32_t id) override
+    {
+         unregisterSurface(id);
+    }
+
     void dispatchFrameCallbacks();
     void releaseBuffer(struct wl_resource* buffer_resource);
 

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -545,8 +545,11 @@ void Instance::unregisterSurface(Surface* surface)
         [surface](const std::pair<uint32_t, Surface*>& value) -> bool {
             return value.second == surface;
         });
-    if (it != m_viewBackendMap.end())
+    if (it != m_viewBackendMap.end()) {
         m_viewBackendMap.erase(it);
+        if (surface->apiClient)
+            surface->apiClient->bridgeConnectionLost(it->first);
+    }
 }
 
 void Instance::dispatchFrameCallbacks(uint32_t bridgeId)

--- a/src/ws.h
+++ b/src/ws.h
@@ -45,6 +45,12 @@ struct APIClient {
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
     virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
+
+    // Invoked when the association with the surface associated with a given
+    // wpe_bridge identifier is no longer valid, typically due to the nested
+    // compositor client being disconnected before having the chance to read
+    // and process a FdoIPC::UnregisterSurface message.
+    virtual void bridgeConnectionLost(uint32_t bridgeId) = 0;
 };
 
 struct Surface {


### PR DESCRIPTION
As each ViewBackend (and hence web view) can get its contents rendered by different WPEWebProcess due to PSON, keep around a list of all the differen bridgeIds which have been associated with it in a `std::vector`. Newly added elements are always pushed at the back, so the most recent association (i.e. the “current” active one) is always the last element. Keeping the list allows getting back to the previously used ones.

----

Fixes #155

Note that this may need some testing with the `devel/multiple-views` and under WebKitGTK before merging.

This is an alternative to #156 which implements a general solution.