### PR TITLE
Set back the ViewBackend to the previous bridge references

### DIFF
--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -68,6 +68,22 @@ public:
     void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) override;
     void exportShmBuffer(struct wl_resource* bufferResource, struct wl_shm_buffer* shmBuffer) override;
     void exportEGLStreamProducer(struct wl_resource*) override;
+
+    /** Set back the ViewBackend to the previous bridge references
+     *
+     * Falling back to the previous bridge Id because the current Surface is
+     * gone. This action prevents inconsistencies by keeping the ViewBackend in
+     * a consistent state pointing to a still valid bridge reference.
+     *
+     * An example of a scenario that could generate this kind of inconsistency
+     * is a failed load request due to content filter policies. In that case,
+     * the client gone situation is reached because
+     */
+    void clientGone(uint32_t id) override
+    {
+         unregisterSurface(id);
+    }
+
     void dispatchFrameCallbacks();
     void releaseBuffer(struct wl_resource* buffer_resource);
 

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -545,8 +545,11 @@ void Instance::unregisterSurface(Surface* surface)
         [surface](const std::pair<uint32_t, Surface*>& value) -> bool {
             return value.second == surface;
         });
-    if (it != m_viewBackendMap.end())
+    if (it != m_viewBackendMap.end()) {
         m_viewBackendMap.erase(it);
+        if (surface->apiClient)
+            surface->apiClient->clientGone(it->first);
+    }
 }
 
 void Instance::dispatchFrameCallbacks(uint32_t bridgeId)

--- a/src/ws.h
+++ b/src/ws.h
@@ -45,6 +45,7 @@ struct APIClient {
     virtual void exportLinuxDmabuf(const struct linux_dmabuf_buffer *dmabuf_buffer) = 0;
     virtual void exportShmBuffer(struct wl_resource*, struct wl_shm_buffer*) = 0;
     virtual void exportEGLStreamProducer(struct wl_resource*) = 0;
+    virtual void clientGone(uint32_t) {};
 };
 
 struct Surface {


### PR DESCRIPTION
Falling back to the previous bridge Id because the current Surface is gone. This action prevents inconsistencies by keeping the ViewBackend i a consistent state pointing to a still valid bridge reference.

An example of a scenario that could generate this kind of inconsistency is a failed load request due to content filter policies. In that case, the client gone situation is reached because

Co-authored-by: Adrian Perez de Castro <aperez@igalia.com>
Acked-by: Adrian Perez de Castro <aperez@igalia.com>
Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>