### PR TITLE
meson: Try wayland-scanner first without pkg-config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,15 +91,13 @@ add_project_arguments(
 	language: ['c', 'cpp']
 )
 
+wayland_scanner_candidates = ['wayland-scanner']
 wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
 if wayland_scanner_dep.found()
-	wayland_scanner = find_program(
-		wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
-		native: true
-	)
-else
-	wayland_scanner = find_program('wayland-scanner', native: true)
+	wayland_scanner_candidates += wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner')
 endif
+
+wayland_scanner = find_program(wayland_scanner_candidates, native: true)
 
 r = run_command(wayland_scanner, '--version')
 assert(r.returncode() == 0,


### PR DESCRIPTION
Try finding the wayland-scanner program first without involving picking its path from the `pkg-config` dependency. This way it is possible to instruct Meson to override the the path where to find it using the `[binaries]` section of a [native file](https://mesonbuild.com/Machine-files.html) during cross-compilation.