### PR TITLE
ws: Avoid using a field of an erased iterator

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -546,9 +546,10 @@ void Instance::unregisterSurface(Surface* surface)
             return value.second == surface;
         });
     if (it != m_viewBackendMap.end()) {
+        const uint32_t bridgeId = it->first;
         m_viewBackendMap.erase(it);
         if (surface->apiClient)
-            surface->apiClient->bridgeConnectionLost(it->first);
+            surface->apiClient->bridgeConnectionLost(bridgeId);
     }
 }
 


### PR DESCRIPTION
Do not use values from an iterator after the element it refers to has been erased from a container, to avoid falling in the pit of undefined behaviour.

Fixes #162