### PR TITLE
Meson updates

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -254,13 +254,15 @@ add_project_arguments(
 	language: 'c'
 )
 
+wpe_dep = dependency('wpe-1.0', version: '>=1.6.0', fallback: ['libwpe', 'libwpe_dep'])
+
 deps = [
 	dependency('epoxy'),
 	dependency('gio-2.0'),
 	dependency('gobject-2.0'),
 	dependency('wayland-client'),
 	dependency('wayland-server'),
-	dependency('wpe-1.0', version: '>=1.6.0', fallback: ['libwpe', 'libwpe_dep']),
+        wpe_dep,
 ]
 
 # Will be set to the library dependency which provides the wl_egl_* functions.
@@ -348,8 +350,7 @@ import('pkgconfig').generate(
 	description: 'The WPEBackend-fdo library',
 	name: 'wpebackend-fdo-' + api_version,
 	subdirs: 'wpe-fdo-' + api_version,
-	libraries: lib,
-	version: meson.project_version(),
+	libraries: [lib, wpe_dep],
 )
 
 if get_option('build_docs')

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -11,7 +11,7 @@ import re
 
 version = {}
 version_re = re.compile(r"^#define\s+WPE_FDO_([A-Z]+)_VERSION\s+(\d+)$")
-version_file = path.join(environ["MESON_SOURCE_ROOT"],
+version_file = path.join(environ["MESON_SOURCE_ROOT"], environ["MESON_SUBDIR"],
                          "include", "wpe", "wpebackend-fdo-version.h")
 
 with open(version_file, "r") as f:


### PR DESCRIPTION
    meson: Use implicit dependencies for required dependencies.
    
    The generated pkgconfig file for the library is incomplete, since application,
    such as cog, only explicity depend on WPEBackend-fdo, though it also depends on
    libwpe. It has not been a problem since wpe-webkit-1.0.pc explicity expose
    libwpe requirement. Still, for robustness and self documentation, it's better to
    express that dependency explicity too.
    
    Also, this patch removes the pkg config version declation since it's also
    handled implicitly by meson.
    
    Previous pc file:
    
    prefix=/usr
    libdir=${prefix}/lib/x86_64-linux-gnu
    includedir=${prefix}/include
    
    Name: wpebackend-fdo-1.0
    Description: The WPEBackend-fdo library
    Version: 1.9.91
    Libs: -L${libdir} -lWPEBackend-fdo-1.0
    Cflags: -I${includedir}/wpe-fdo-1.0
    
    New pc file:
    
    prefix=/usr/local
    libdir=${prefix}/lib
    includedir=${prefix}/include
    
    Name: wpebackend-fdo-1.0
    Description: The WPEBackend-fdo library
    Version: 1.9.1
    Requires: wpe-1.0
    Requires.private: xkbcommon, egl
    Libs: -L${libdir} -lWPEBackend-fdo-1.0
    Libs.private: -ldl
    Cflags: -I${includedir}/wpe-fdo-1.0

----

    meson: Support meson's subproject layout.
    
    As libwpe, wpebackend-fdo can be used as a meson's subproject.
