### PR TITLE
Fix SIGSEGV in WebKit2 applications

### DIFF
--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -267,9 +267,11 @@ public:
 private:
     struct wpe_fdo_egl_exported_image* findImage(struct wl_resource* bufferResource)
     {
-        if (auto* listener = wl_resource_get_destroy_listener(bufferResource, bufferDestroyListenerCallback)) {
-            struct wpe_fdo_egl_exported_image* image;
-            return wl_container_of(listener, image, bufferDestroyListener);
+        if (bufferResource) {
+            if (auto* listener = wl_resource_get_destroy_listener(bufferResource, bufferDestroyListenerCallback)) {
+                struct wpe_fdo_egl_exported_image* image;
+                return wl_container_of(listener, image, bufferDestroyListener);
+            }
         }
 
         return nullptr;

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -247,8 +247,6 @@ public:
 
     void releaseImage(struct wpe_fdo_egl_exported_image* image)
     {
-        image->exported = false;
-
         if (image->bufferResource)
             viewBackend->releaseBuffer(image->bufferResource);
         else
@@ -297,9 +295,6 @@ private:
         image = wl_container_of(listener, image, bufferDestroyListener);
 
         image->bufferResource = nullptr;
-
-        if (!image->exported)
-            deleteImage(image);
     }
 };
 


### PR DESCRIPTION
Detected this SIGSEGV when trying to login to game stores in Lutris.
May fix #175 
Also fixes crashes in Epiphany, and possibly in other WebKit2 applications as well.