### PR TITLE
CI: Update component versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,23 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Debian Packages
         run: |
           sudo apt update
           sudo apt install -y flex libjson-glib-dev libxkbcommon-dev \
-            libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev llvm-dev \
-            libclang-dev libglib2.0-dev libepoxy-dev ninja-build
+            libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev \
+            libwayland-dev llvm-dev libclang-dev libglib2.0-dev \
+            libepoxy-dev ninja-build
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.5
+          python-version: '3.6'
       - name: Python Package Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
@@ -29,7 +30,7 @@ jobs:
       - name: Install Python Packages
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson==0.49
+          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson==0.55
       - name: Fetch libwpe
         run: |
           if [[ -d ~/libwpe/.git ]] ; then
@@ -55,7 +56,7 @@ jobs:
         run: |
           DESTDIR="$(pwd)/_work/files" ninja -C _work/build install
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: build
           path: _work


### PR DESCRIPTION
Switch to Ubuntu 20.04LTS, which is the oldest currently supported, and Python to 3.6 which is the lowest available for 20.04. Bump the Meson dependency to 0.55, because libwpe has started requiring it.

Update to the latest versions of the GitHub Actions, while at it.