### PR TITLE
Remove image on buffer destroy callback only

### DIFF
--- a/src/view-backend-exportable-fdo-egl-private.h
+++ b/src/view-backend-exportable-fdo-egl-private.h
@@ -33,7 +33,6 @@ struct wpe_fdo_egl_exported_image {
     EGLImageKHR eglImage { nullptr };
     uint32_t width { 0 };
     uint32_t height { 0 };
-    bool exported { false };
     struct wl_resource* bufferResource { nullptr };
     struct wl_listener bufferDestroyListener;
 };

--- a/src/view-backend-exportable-fdo-egl.cpp
+++ b/src/view-backend-exportable-fdo-egl.cpp
@@ -249,8 +249,6 @@ public:
     {
         if (image->bufferResource)
             viewBackend->releaseBuffer(image->bufferResource);
-        else
-            deleteImage(image);
     }
 
     void releaseShmBuffer(struct wpe_fdo_shm_exported_buffer* buffer)
@@ -277,7 +275,6 @@ private:
 
     void exportImage(struct wpe_fdo_egl_exported_image* image)
     {
-        image->exported = true;
         client->export_fdo_egl_image(data, image);
     }
 
@@ -295,6 +292,8 @@ private:
         image = wl_container_of(listener, image, bufferDestroyListener);
 
         image->bufferResource = nullptr;
+
+        deleteImage(image);
     }
 };
 


### PR DESCRIPTION
view-backend-exportable-fdo-egl.cpp relies on the bufferDestroyListenerCallback for destroying the image, This is called during the wl_resource_destroy() to release the image.

Related-to: #175 #176




