### PR TITLE
ws: Save and expose damage buffer information

### DIFF
--- a/include/wpe/exported-image-egl.h
+++ b/include/wpe/exported-image-egl.h
@@ -49,6 +49,9 @@ wpe_fdo_egl_exported_image_get_height(struct wpe_fdo_egl_exported_image*);
 EGLImageKHR
 wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image*);
 
+uint32_t
+wpe_fdo_egl_exported_image_get_damage_regions(struct wpe_fdo_egl_exported_image*, const int32_t**);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -52,4 +52,11 @@ wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image* imag
     return image->eglImage;
 }
 
+__attribute__((visibility("default")))
+uint32_t
+wpe_fdo_egl_exported_image_get_damage_regions(struct wpe_fdo_egl_exported_image* image, const int32_t** target)
+{
+    return WS::Instance::singleton().exportDamageRegions(image->bufferResource, target);
+}
+
 }

--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -260,7 +260,7 @@ const struct wl_registry_listener BaseTarget::s_registryListener = {
         auto& target = *reinterpret_cast<BaseTarget*>(data);
 
         if (!std::strcmp(interface, "wl_compositor"))
-            target.m_wl.compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 1));
+            target.m_wl.compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 4));
         if (!std::strcmp(interface, "wpe_bridge"))
             target.m_wl.wpeBridge = static_cast<struct wpe_bridge*>(wl_registry_bind(registry, name, &wpe_bridge_interface, 1));
         if (!std::strcmp(interface, "wpe_dmabuf_pool_manager"))

--- a/src/ws.h
+++ b/src/ws.h
@@ -30,6 +30,7 @@
 #include <glib.h>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 #include <wayland-server.h>
 
 struct linux_dmabuf_buffer;
@@ -152,6 +153,9 @@ public:
 
     void registerSurface(uint32_t, Surface*);
     void unregisterSurface(Surface*);
+    void addBufferDamageRegion(struct wl_resource*, int32_t x, int32_t y, int32_t width, int32_t height);
+    void clearPendingBufferDamage(struct wl_resource*);
+    uint32_t exportDamageRegions(struct wl_resource*, const int32_t** target);
     void registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
     bool dispatchFrameCallbacks(uint32_t);
@@ -188,6 +192,7 @@ private:
     struct wl_global* m_wpeBridge { nullptr };
     struct wl_global* m_wpeDmabufPoolManager { nullptr };
     GSource* m_source { nullptr };
+    std::unordered_map<struct wl_resource*, std::vector<std::array<int32_t, 4>>> m_damageRegions;
 
     // (bridgeId -> Surface)
     std::unordered_map<uint32_t, Surface*> m_viewBackendMap;


### PR DESCRIPTION
The wl_surface.damage_buffer request can be used by clients to inform that a given region (in buffer coordinates) is damaged. This request is used by eglSwapBuffersWithDamage[EXT|KHR], with one call for each rect.

For more info: https://wayland-book.com/surfaces-in-depth/damaging-surfaces.html

This commit stores this information and exposes it to exported EGL image clients.

It also bumps the nested compositor interface to version 4, which provides the damage_buffer support.