### PR TITLE
meson: Require version 0.52.1, remove docs workaround

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('wpebackend-fdo', ['c', 'cpp'],
-	meson_version: '>=0.49',
+	meson_version: '>=0.52.1',
 	default_options: [
 		'b_ndebug=if-release',
 		'c_std=c99',
@@ -368,8 +368,6 @@ if get_option('build_docs')
 		c_smart_index: true,
 		c_sources: api_headers,
 		c_include_directories: ['include', meson.current_build_dir()],
-		# The space here is relevant, see
-		# https://github.com/mesonbuild/meson/issues/5800#issuecomment-552198354
-		extra_c_flags: [' -DWPE_FDO_COMPILATION=1'],
+		extra_c_flags: ['-DWPE_FDO_COMPILATION=1'],
 	)
 endif


### PR DESCRIPTION
Update to Meson 0.52.1, which should be available in all supported systems. This allows removing a workaround for documentation as the new Meson version includes a fixed HotDoc module.

----

Meson fix included in 0.52.1 and newer: https://github.com/mesonbuild/meson/pull/6163