### PR TITLE
ws: Save and expose damaged image regions (v2)

### DIFF
--- a/include/wpe/exported-image-egl.h
+++ b/include/wpe/exported-image-egl.h
@@ -85,6 +85,9 @@ wpe_fdo_egl_exported_image_get_height(struct wpe_fdo_egl_exported_image *image);
 EGLImageKHR
 wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image *image);
 
+uint32_t
+wpe_fdo_egl_exported_image_get_damage_regions(struct wpe_fdo_egl_exported_image*, const int32_t**);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/wpe/exported-image-egl.h
+++ b/include/wpe/exported-image-egl.h
@@ -30,6 +30,18 @@
 #ifndef __exported_image_egl_h__
 #define __exported_image_egl_h__
 
+/**
+ * SECTION:egl_exported_image
+ * @short_description: EGL exported images.
+ * @include wpe/fdo-egl.h
+ *
+ * Represents an EGL exported image with some associated attributes.
+ *
+ * An `wpe_fdo_egl_exported_image` represents an `EGLImageKHR` object,
+ * which may be retrieved using wpe_fdo_egl_exported_image_get_egl_image(),
+ * and provides additional information about it.
+ */
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -40,14 +52,38 @@ typedef void* EGLImageKHR;
 
 struct wpe_fdo_egl_exported_image;
 
+/**
+ * wpe_fdo_egl_exported_image_get_width:
+ * @image: (transfer none): An exported EGL image.
+ *
+ * Gets the width of an exported @image.
+ *
+ * Returns: Image width.
+ */
 uint32_t
-wpe_fdo_egl_exported_image_get_width(struct wpe_fdo_egl_exported_image*);
+wpe_fdo_egl_exported_image_get_width(struct wpe_fdo_egl_exported_image *image);
 
+/**
+ * wpe_fdo_egl_exported_image_get_height:
+ * @image: (transfer none): An exported EGL image.
+ *
+ * Gets the height of an exported @image.
+ *
+ * Returns: Image height.
+ */
 uint32_t
-wpe_fdo_egl_exported_image_get_height(struct wpe_fdo_egl_exported_image*);
+wpe_fdo_egl_exported_image_get_height(struct wpe_fdo_egl_exported_image *image);
 
+/**
+ * wpe_fdo_egl_exported_image_get_egl_image:
+ * @image: (transfer none): An exported EGL image.
+ *
+ * Gets the `EGLImage` for en exported @image.
+ *
+ * Returns: (transfer none): An `EGLImage` handle.
+ */
 EGLImageKHR
-wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image*);
+wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image *image);
 
 #ifdef __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -255,14 +255,22 @@ add_project_arguments(
 )
 
 wpe_dep = dependency('wpe-1.0', version: '>=1.6.0', fallback: ['libwpe', 'libwpe_dep'])
+wl_server_dep = dependency('wayland-server')
+
+assert(cxx.has_header_symbol('wayland-server.h', 'WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION', dependencies: wl_server_dep),
+    'Including <wayland-server.h> does not define WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION')
+assert(cxx.has_member('struct wl_surface_interface', 'damage_buffer',
+    prefix: '#include <wayland-server.h>',
+    dependencies: wl_server_dep),
+    'struct member wl_surface_interface::damage_buffer is not defined')
 
 deps = [
-	dependency('epoxy'),
-	dependency('gio-2.0'),
-	dependency('gobject-2.0'),
-	dependency('wayland-client'),
-	dependency('wayland-server'),
-        wpe_dep,
+    dependency('epoxy'),
+    dependency('gio-2.0'),
+    dependency('gobject-2.0'),
+    dependency('wayland-client'),
+    wl_server_dep,
+    wpe_dep,
 ]
 
 # Will be set to the library dependency which provides the wl_egl_* functions.

--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -52,4 +52,11 @@ wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image* imag
     return image->eglImage;
 }
 
+__attribute__((visibility("default")))
+uint32_t
+wpe_fdo_egl_exported_image_get_damage_regions(struct wpe_fdo_egl_exported_image* image, const int32_t** target)
+{
+    return WS::Instance::singleton().exportDamageRegions(image->bufferResource, target);
+}
+
 }

--- a/src/exported-image-egl.cpp
+++ b/src/exported-image-egl.cpp
@@ -53,10 +53,19 @@ wpe_fdo_egl_exported_image_get_egl_image(struct wpe_fdo_egl_exported_image* imag
 }
 
 __attribute__((visibility("default")))
-uint32_t
-wpe_fdo_egl_exported_image_get_damage_regions(struct wpe_fdo_egl_exported_image* image, const int32_t** target)
+const struct wpe_fdo_rect*
+wpe_fdo_egl_exported_image_get_damage_regions(struct wpe_fdo_egl_exported_image *image, uint32_t *n_rectangles)
 {
-    return WS::Instance::singleton().exportDamageRegions(image->bufferResource, target);
+    g_return_val_if_fail(n_rectangles, nullptr);
+
+    const auto* regions = WS::Instance::singleton().getDamageRegions(image->bufferResource);
+    if (regions && regions->size()) {
+        *n_rectangles = regions->size();
+        return regions->data();
+    } else {
+        *n_rectangles = 0;
+        return nullptr;
+    }
 }
 
 }

--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -260,7 +260,7 @@ const struct wl_registry_listener BaseTarget::s_registryListener = {
         auto& target = *reinterpret_cast<BaseTarget*>(data);
 
         if (!std::strcmp(interface, "wl_compositor"))
-            target.m_wl.compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 1));
+            target.m_wl.compositor = static_cast<struct wl_compositor*>(wl_registry_bind(registry, name, &wl_compositor_interface, 4));
         if (!std::strcmp(interface, "wpe_bridge"))
             target.m_wl.wpeBridge = static_cast<struct wpe_bridge*>(wl_registry_bind(registry, name, &wpe_bridge_interface, 1));
         if (!std::strcmp(interface, "wpe_dmabuf_pool_manager"))

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -91,7 +91,10 @@ GSourceFuncs ServerSource::s_sourceFuncs = {
 
 static const struct wl_surface_interface s_surfaceInterface = {
     // destroy
-    [](struct wl_client*, struct wl_resource*) { },
+    [](struct wl_client*, struct wl_resource *surfaceResource) {
+        auto& surface = *static_cast<Surface*>(wl_resource_get_user_data(surfaceResource));
+        Instance::singleton().clearPendingBufferDamage(surface.bufferResource);
+    },
     // attach
     [](struct wl_client*, struct wl_resource* surfaceResource, struct wl_resource* bufferResource, int32_t, int32_t)
     {

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -100,7 +100,9 @@ static const struct wl_surface_interface s_surfaceInterface = {
         Instance::singleton().impl().surfaceAttach(surface, bufferResource);
     },
     // damage
-    [](struct wl_client*, struct wl_resource*, int32_t, int32_t, int32_t, int32_t) { },
+    [](struct wl_client*, struct wl_resource*, int32_t, int32_t, int32_t, int32_t) {
+        g_warning_once("%s:%u: wl_surface_interface::set_buffer_transform is a no-op", __FILE__, __LINE__);
+    },
     // frame
     [](struct wl_client* client, struct wl_resource* surfaceResource, uint32_t callback)
     {
@@ -121,9 +123,13 @@ static const struct wl_surface_interface s_surfaceInterface = {
         surface.addFrameCallback(callbackResource);
     },
     // set_opaque_region
-    [](struct wl_client*, struct wl_resource*, struct wl_resource*) { },
+    [](struct wl_client*, struct wl_resource*, struct wl_resource*) {
+        g_warning_once("%s:%u: wl_surface_interface::set_buffer_transform is a no-op", __FILE__, __LINE__);
+    },
     // set_input_region
-    [](struct wl_client*, struct wl_resource*, struct wl_resource*) { },
+    [](struct wl_client*, struct wl_resource*, struct wl_resource*) {
+        g_warning_once("%s:%u: wl_surface_interface::set_buffer_transform is a no-op", __FILE__, __LINE__);
+    },
     // commit
     [](struct wl_client*, struct wl_resource* surfaceResource)
     {
@@ -134,9 +140,13 @@ static const struct wl_surface_interface s_surfaceInterface = {
         WS::Instance::singleton().clearPendingBufferDamage(bufferResource);
     },
     // set_buffer_transform
-    [](struct wl_client*, struct wl_resource*, int32_t) { },
+    [](struct wl_client*, struct wl_resource*, int32_t) {
+        g_warning_once("%s:%u: wl_surface_interface::set_buffer_transform is a no-op", __FILE__, __LINE__);
+    },
     // set_buffer_scale
-    [](struct wl_client*, struct wl_resource*, int32_t) { },
+    [](struct wl_client*, struct wl_resource*, int32_t) {
+        g_warning_once("%s:%u: wl_surface_interface::set_buffer_scale is a no-op", __FILE__, __LINE__);
+    },
     // damage_buffer
     [](struct wl_client*, struct wl_resource* surfaceResource, int32_t x, int32_t y, int32_t width, int32_t height) {
         auto& surface = *static_cast<Surface*>(wl_resource_get_user_data(surfaceResource));

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -137,14 +137,15 @@ static const struct wl_surface_interface s_surfaceInterface = {
     [](struct wl_client*, struct wl_resource*, int32_t) { },
     // set_buffer_scale
     [](struct wl_client*, struct wl_resource*, int32_t) { },
-#if (WAYLAND_VERSION_MAJOR > 1) || (WAYLAND_VERSION_MAJOR == 1 && WAYLAND_VERSION_MINOR >= 10)
     // damage_buffer
     [](struct wl_client*, struct wl_resource* surfaceResource, int32_t x, int32_t y, int32_t width, int32_t height) {
         auto& surface = *static_cast<Surface*>(wl_resource_get_user_data(surfaceResource));
         WS::Instance::singleton().addBufferDamageRegion(surface.bufferResource, x, y, width, height);
     },
-#endif
 };
+
+G_STATIC_ASSERT(WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION >= WL_SURFACE_SET_BUFFER_TRANSFORM_SINCE_VERSION);
+G_STATIC_ASSERT(WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION);
 
 static const struct wl_compositor_interface s_compositorInterface = {
     // create_surface
@@ -422,7 +423,7 @@ Instance::Instance(std::unique_ptr<Impl>&& impl)
 {
     m_impl->setInstance(*this);
 
-    m_compositor = wl_global_create(m_display, &wl_compositor_interface, 4, this,
+    m_compositor = wl_global_create(m_display, &wl_compositor_interface, WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION, this,
         [](struct wl_client* client, void*, uint32_t version, uint32_t id)
         {
             struct wl_resource* resource = wl_resource_create(client, &wl_compositor_interface, version, id);

--- a/src/ws.h
+++ b/src/ws.h
@@ -30,6 +30,7 @@
 #include <glib.h>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 #include <wayland-server.h>
 
 struct linux_dmabuf_buffer;
@@ -152,6 +153,9 @@ public:
 
     void registerSurface(uint32_t, Surface*);
     void unregisterSurface(Surface*);
+    void addBufferDamageRegion(struct wl_resource*, int32_t x, int32_t y, int32_t width, int32_t height);
+    void clearPendingBufferDamage(struct wl_resource*);
+    uint32_t exportDamageRegions(struct wl_resource*, const int32_t** target);
     void registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
     bool dispatchFrameCallbacks(uint32_t);
@@ -188,6 +192,7 @@ private:
     struct wl_global* m_wpeBridge { nullptr };
     struct wl_global* m_wpeDmabufPoolManager { nullptr };
     GSource* m_source { nullptr };
+    std::unordered_map<struct wl_resource*, std::vector<std::array<int32_t, 4>>> m_damageRegions;
 
     // (bridgeId -> Surface)
     std::unordered_map<uint32_t, Surface*> m_viewBackendMap;

--- a/src/ws.h
+++ b/src/ws.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "../include/wpe/exported-image-egl.h"
 #include "ws-types.h"
 #include <functional>
 #include <glib.h>
@@ -153,9 +154,9 @@ public:
 
     void registerSurface(uint32_t, Surface*);
     void unregisterSurface(Surface*);
-    void addBufferDamageRegion(struct wl_resource*, int32_t x, int32_t y, int32_t width, int32_t height);
+    void addBufferDamageRegion(struct wl_resource*, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void clearPendingBufferDamage(struct wl_resource*);
-    uint32_t exportDamageRegions(struct wl_resource*, const int32_t** target);
+    const std::vector<struct wpe_fdo_rect>* getDamageRegions(struct wl_resource* bufferResource);
     void registerViewBackend(uint32_t, APIClient&);
     void unregisterViewBackend(uint32_t);
     bool dispatchFrameCallbacks(uint32_t);
@@ -192,7 +193,7 @@ private:
     struct wl_global* m_wpeBridge { nullptr };
     struct wl_global* m_wpeDmabufPoolManager { nullptr };
     GSource* m_source { nullptr };
-    std::unordered_map<struct wl_resource*, std::vector<std::array<int32_t, 4>>> m_damageRegions;
+    std::unordered_map<struct wl_resource*, std::vector<struct wpe_fdo_rect>> m_damageRegions;
 
     // (bridgeId -> Surface)
     std::unordered_map<uint32_t, Surface*> m_viewBackendMap;


### PR DESCRIPTION
This builds upon #184, with the following additions:

- Meson will check that the Wayland headers define the needed symbols to use `wl_surface_damage_buffer()`, erroring if not available. The functionality is now always built-in. This should not be an issue because any reasonable Wayland version should have it.
- Plugs a leak that would leave stale entries in the `unordered_map` that associates a buffer with its damaged regions list when a buffer is destroyed.
- Stores damage regions using a new `wpe_fdo_rect` type, which makes the code easier to follow, and documents the damage support, explicitly indicating that top-left is used as origin of coordinates for damage.
- Adds warnings to make developers notice if any of the stubbed methods from `wl_surface_interface` ends up being used.

Thanks to @lauromoura for the first version of the patch set 🙏🏼 