### PR TITLE
Cast to EGLNativeWindowType explicitly

### DIFF
--- a/src/egl-client-wayland.cpp
+++ b/src/egl-client-wayland.cpp
@@ -63,7 +63,7 @@ TargetWayland::~TargetWayland()
 
 EGLNativeWindowType TargetWayland::nativeWindow() const
 {
-    return m_egl.window;
+    return (EGLNativeWindowType) m_egl.window;
 }
 
 void TargetWayland::resize(uint32_t width, uint32_t height)


### PR DESCRIPTION
In order to avoid off build failures due to mismatching (but compatible) declarations of `wl_egl_window` and `EGLNativeWindowType`, add an explicit cast to EGLNativeWindowType inside the `TargetWayland::nativeWindow()` function.

Solves the following build issue found by the Buildroot autobuilders:

- http://autobuild.buildroot.net/results/92c5cc3134e92c263a0cbb4c05ef8956569e434b/