### PR TITLE
Fix wpe_dmabuf_pool object leak

### DIFF
--- a/src/ws-client.cpp
+++ b/src/ws-client.cpp
@@ -187,6 +187,7 @@ BaseTarget::~BaseTarget()
 
     g_clear_pointer(&m_wl.frameCallback, wl_callback_destroy);
     g_clear_pointer(&m_wl.surface, wl_surface_destroy);
+    g_clear_pointer(&m_wl.wpeDmabufPool, wpe_dmabuf_pool_destroy);
 
     g_clear_pointer(&m_wl.wpeDmabufPoolManager, wpe_dmabuf_pool_manager_destroy);
     g_clear_pointer(&m_wl.wpeBridge, wpe_bridge_destroy);


### PR DESCRIPTION
Fixes wayland library warning on exit:
```
warning: queue 0x887860 destroyed while proxies still attached:
  wpe_dmabuf_pool@12 still attached
```