### PR TITLE
CI: Update to use actions/upload-artifact v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           DESTDIR="$(pwd)/_work/files" ninja -C _work/build install
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: _work


### PR DESCRIPTION
Update to v4 of the upload-artifact GitHub action. The newer version is faster, and v3 is going to be deprecated next November:

  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/