### PR TITLE
src/ipc.h: Include <stdint.h> for uint32_t

### DIFF
--- a/src/ipc.h
+++ b/src/ipc.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <gio/gio.h>
+#include <stdint.h>
 #include <memory>
 
 namespace FdoIPC {


### PR DESCRIPTION
Without this the build fails with the upcoming gcc 15:

In file included from ../wpebackend-fdo-1.14.2/src/ipc.cpp:26: ../wpebackend-fdo-1.14.2/src/ipc.h:36:36: error: 'uint32_t' has not been declared
   36 |     virtual void didReceiveMessage(uint32_t messageId, uint32_t messageBody) = 0