### PR TITLE
src/ws-egl.cpp: add missing unistd.h header

### DIFF
--- a/src/ws-egl.cpp
+++ b/src/ws-egl.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #ifndef EGL_WL_bind_wayland_display
 #define EGL_WAYLAND_BUFFER_WL 0x31D5


### PR DESCRIPTION
This addresses build failures with musl:

| ../../../../../../workspace/sources/wpebackend-fdo/src/ws-egl.cpp: In destructor 'virtual WS::ImplEGL::~ImplEGL()': | ../../../../../../workspace/sources/wpebackend-fdo/src/ws-egl.cpp:83:9: error: 'close' was not declared in this scope; did you mean 'clone'?
|    83 |         close(m_dmabuf.formatTable.fd);
|       |         ^~~~~
|       |         clone
| ../../../../../../workspace/sources/wpebackend-fdo/src/ws-egl.cpp: In member function 'void WS::ImplEGL::initFormatTable()':
| ../../../../../../workspace/sources/wpebackend-fdo/src/ws-egl.cpp:397:15: error: 'ftruncate' was not declared in this scope; did you mean 'strncat'?
|   397 |         ret = ftruncate(fd, size);
|       |               ^~~~~~~~~
|       |               strncat